### PR TITLE
improvement round 2

### DIFF
--- a/docs/xtr/arrays.md
+++ b/docs/xtr/arrays.md
@@ -356,19 +356,21 @@ xtr.arrays.unzip([[1, 'x'], [2, 'y'], [3, 'z']])
 [[1, 2, 3], ['x', 'y', 'z']]
 ```
 
-[//]: # (## `unzipAll&#40;arr: Array[Array[A]], fill: B&#41;: Array[Array[A|B]]`)
-[//]: # (Create n-number of `Arrays`, each containing the n-th element of every array in `arr`, using a `fill` value for missing n-th elements.)
-[//]: # ()
-[//]: # (Returns a new `Array` of equal size to the longest array in `arr`. Every n-th element in the result is an `Array` containing the n-th element the arrays in `arr` that have such element or `fill` for short arrays.)
-[//]: # ()
-[//]: # (**Example**)
-[//]: # (```)
-[//]: # (xtr.arrays.unzipAll&#40;[[1, 'x'], [2], [3, 'z']], 'NA'&#41;)
-[//]: # (```)
-[//]: # (**Result**)
-[//]: # (```)
-[//]: # ([[1, 2, 3], ['x', 'NA', 'z']])
-[//]: # (```)
+## unzipAll
+`unzipAll(arr: Array[Array[A]], fill: B): Array[Array[A|B]]`
+
+Create n-number of `Arrays`, each containing the n-th element of every array in `arr`, using a `fill` value for missing n-th elements.
+
+Returns a new `Array` of equal size to the longest array in `arr`. Every n-th element in the result is an `Array` containing the n-th element of the arrays in `arr` that have such element, or `fill` for short arrays.
+
+**Example**
+```
+xtr.arrays.unzipAll([[1, 'x'], [2], [3, 'z']], 'NA')
+```
+**Result**
+```
+[[1, 2, 3], ['x', 'NA', 'z']]
+```
 
 <br/>
 ## zip
@@ -387,16 +389,18 @@ xtr.arrays.zip([1, 2, 3], ['x', 'y', 'z'])
 [[1, 'x'], [2, 'y'], [3, 'z']]
 ```
 
-[//]: # (## `zipAll&#40;arr: Array[Array[A]], fill: B&#41;: Array[Array[A|B]]`)
-[//]: # (Combines corresponding elements of the arrays in `arr`, using a `fill` value for short arrays.)
-[//]: # ()
-[//]: # (Returns a new `Array` of equal size to the longest array in `arr`. Every n-th element in the result is an `Array` containing the n-th element of the arrays in `arr` that have such element or `fill` for short arrays.)
-[//]: # ()
-[//]: # (**Example**)
-[//]: # (```)
-[//]: # (xtr.arrays.zipAll&#40;[[1, 2, 3], ['x', 'y']], 'NA'&#41;)
-[//]: # (```)
-[//]: # (**Result**)
-[//]: # (```)
-[//]: # ([[1, 'x'], [2, 'y'], [3, 'NA']])
-[//]: # (```)
+## zipAll
+`zipAll(arr: Array[Array[A]], fill: B): Array[Array[A|B]]`
+
+Combines corresponding elements of the arrays in `arr`, using a `fill` value for short arrays.
+
+Returns a new `Array` of equal size to the longest array in `arr`. Every n-th element in the result is an `Array` containing the n-th element of the arrays in `arr` that have such element, or `fill` for short arrays.
+
+**Example**
+```
+xtr.arrays.zipAll([[1, 2, 3], ['x', 'y']], 'NA')
+```
+**Result**
+```
+[[1, 'x'], [2, 'y'], [3, 'NA']]
+```

--- a/docs/xtr/arrays.md
+++ b/docs/xtr/arrays.md
@@ -1,9 +1,9 @@
 # xtr.arrays
 
 ## all
-`all(arr: Array[A], predicate: Func[(A) => Boolean]): Boolean`
+`all(value: Array[A], func: Func[(A) => Boolean]): Boolean`
 
-Returns `true` if all elements in `arr` satisfy the given `predicate`, otherwise `false`. `predicate` must accept an `A`.
+Returns `true` if all elements in `value` satisfy the given `func`, otherwise `false`. `func` must accept an `A`.
 
 **Example**
 ```
@@ -16,9 +16,9 @@ true
 
 <br/>
 ## any
-`any(arr: Array[A], function: Func[(A) => Boolean]): Boolean`
+`any(value: Array[A], func: Func[(A) => Boolean]): Boolean`
 
-Returns `true` if any element in `arr` satisfies the given `predicate`, otherwise `false`. `predicate` must accept an `A`.
+Returns `true` if any element in `value` satisfies the given `func`, otherwise `false`. `func` must accept an `A`.
 
 **Example**
 ```
@@ -31,11 +31,11 @@ true
 
 <br/>
 ## break
-`break(arr: Array[A], predicate: Func[(A) => Boolean]): Object[Array[A]]`
+`break(arr: Array[A], func: Func[(A) => Boolean]): Object[Array[A]]`
 
 Returns an `Object` with two entries:
 
-- `left` key with an `Array[A]` containing the elements of `arr` before the first element to satisfy the given `predicate`.
+- `left` key with an `Array[A]` containing the elements of `arr` before the first element to satisfy the given `func`.
 - `right` key with an `Array[A]` containing the remaining elements of `arr`.
 
 **Example**
@@ -49,9 +49,9 @@ xtr.arrays.break([1, 2, 3, 4, 5], function(item) item % 2 == 0)
 
 <br/>
 ## chunksOf
-`chunksOf(arr: Array[A], size: Number): Array[Array[A]]`
+`chunksOf(array: Array[A], size: Number): Array[Array[A]]`
 
-Returns a new `Array` of `Array[A]`, with every element containing the next `size` elements in `arr`.
+Returns a new `Array` of `Array[A]`, with every element containing the next `size` elements in `array`.
 
 **Example**
 ```
@@ -64,9 +64,9 @@ xtr.arrays.chunksOf([1, 2, 3, 4, 5], 2)
 
 <br/>
 ## countBy
-`countBy(arr: Array[A], predicate: Func[(A) => Boolean]): Number`
+`countBy(arr: Array[A], func: Func[(A) => Boolean]): Number`
 
-Returns a `Number` count of all the elements in `array` that satisfy the given `predicate`, which must accept and `A`.
+Returns a `Number` count of all the elements in `arr` that satisfy the given `func`, which must accept an `A`.
 
 **Example**
 ```
@@ -80,9 +80,9 @@ xtr.arrays.countBy([1, 2, 3], function(item) item > 2)
 <br/>
 ## distinctBy
 ### distinctBy func(value)
-`distinctBy(arr: Array[A], identity: Func[(A) => B]): Array[A]`
+`distinctBy(container: Array[A], func: Func[(A) => B]): Array[A]`
 
-Returns a new `Array` with the distinct elements in `arr` using the given `identity` function for comparison. `identity` must accept an `A`.
+Returns a new `Array` with the distinct elements in `container` using the given `func` function for comparison. `func` must accept an `A`.
 
 **Example**
 ```
@@ -97,26 +97,26 @@ The modulo operation on the elements yields `[1, 2, 0, 1, 2, 0]` meaning `1` and
 
 <br/>
 ### distinctBy func(value, idx)
-`distinctBy(arr: Array[A], identity: Func[(A, Number) => B]): Array[A]`
+`distinctBy(container: Array[A], func: Func[(A, Number) => B]): Array[A]`
 
-Returns a new `Array` with the distinct elements in `arr` using the given `identity` function for comparison. `identity` must accept an `A`.
+Returns a new `Array` with the distinct elements in `container` using the given `func` function for comparison. `func` must accept an `A` and its `Number` index.
 
 **Example**
 ```
-xtr.arrays.distinctBy([1, 2, 3, 4, 5, 6], function(item, idx) item % (3 * idx))
+xtr.arrays.distinctBy([1, 2, 3, 4, 5, 6], function(item, idx) (item + idx) % 3)
 ```
 **Result**
 ```
-[1, 2, 3, 4, 5, 6]
+[1, 2, 3]
 ```
 
-The modulo operation on the elements yields `[0, 2, 3, 4, 5, 6]` where all are distinct, so all elements are kept.
+The computation on the elements yields `[1, 0, 2, 1, 0, 2]`, meaning `4`, `5`, and `6` share an identity with `1`, `2`, and `3` respectively, so they are discarded.
 
 <br/>
 ## drop
-`drop(arr: Array[A], n: Number): Array[A]`
+`drop(arr: Array[A], num: Number): Array[A]`
 
-Returns a new `Array` with the elements in `arr` but dropping the first `n` elements.
+Returns a new `Array` with the elements in `arr` but dropping the first `num` elements.
 
 **Example**
 ```
@@ -129,9 +129,9 @@ xtr.arrays.drop([1, 2, 3, 4, 5], 3)
 
 <br/>
 ## dropWhile
-`dropWhile(arr: Array[A], predicate: Func[(A) => Boolean]): Array[A]`
+`dropWhile(arr: Array[A], func: Func[(A) => Boolean]): Array[A]`
 
-Returns a new `Array` with the elements in `arr`, but dropping the first elements while they satisfy the given `predicate`, which must accept an `A`.
+Returns a new `Array` with the elements in `arr`, but dropping the first elements while they satisfy the given `func`, which must accept an `A`.
 
 **Example**
 ```
@@ -144,10 +144,10 @@ xtr.arrays.dropWhile([1, 2, 3, 4, 5], function(item) item * 3 < 10)
 
 <br/>
 ## duplicatesBy
-`duplicatesBy(arr: Array[A], identity: Func[(A) => B]): Array[A]`
+`duplicatesBy(array: Array[A], func: Func[(A) => B]): Array[A]`
 
-Returns a new `Array` with the elements in `arr` whose `identity` is shared by more than one element. Each
-duplicated identity contributes the first element that produced it, in the order they appear in `arr`.
+Returns a new `Array` with the elements in `array` whose identity, as computed by `func`, is shared by more than one element. Each
+duplicated identity contributes the first element that produced it, in the order they appear in `array`.
 
 **Example**
 ```
@@ -170,9 +170,9 @@ xtr.arrays.duplicatesBy([{ id: 1, n: 'a' }, { id: 2, n: 'c' }, { id: 1, n: 'b' }
 <br/>
 ## find
 ### find func(value)
-`find(arr: Array[A], predicate: Func[(A) => Boolean]): [A]`
+`find(arr: Array[A], func: Func[(A) => Boolean]): Array[A]`
 
-Returns a single element `Array` with the first `A` that satisfies the given `predicate`, which must accept an `A`.
+Returns a single element `Array` with the first `A` that satisfies the given `func`, which must accept an `A`.
 
 **Example**
 ```
@@ -185,9 +185,9 @@ xtr.arrays.find([1, 2, 3, 4, 5], function(item) item * 3 > 10)
 
 <br/>
 ### find func(value, idx)
-`find(arr: Array[A], predicate: Func[(A, Number) => Boolean]): [A]`
+`find(arr: Array[A], func: Func[(A, Number) => Boolean]): Array[A]`
 
-Returns a single element `Array` with the first `A` that satisfies the given `predicate`, which must accept an `A` and its `Number` index.
+Returns a single element `Array` with the first `A` that satisfies the given `func`, which must accept an `A` and its `Number` index.
 
 **Example**
 ```
@@ -200,7 +200,7 @@ xtr.arrays.find([1, 2, 3, 4, 5], function(item, idx) item * (3 + idx) > 10)
 
 <br/>
 ## flat
-`flat(arr: Array[Array[A]]): Array[Any]`
+`flat(arr: Array[Any]): Array[Any]`
 
 Returns a new single level `Array` with the contents of all `Array` in `arr`, recursively flattening each `Array` element found.
 
@@ -215,9 +215,9 @@ xtr.arrays.flat([[1, 2], '3', [4, {}, [5, 6]]])
 
 <br/>
 ## indexWhere
-`indexWhere(arr: Array[A], predicate: Func[(A) => Boolean]): Number`
+`indexWhere(arr: Array[A], func: Func[(A) => Boolean]): Number`
 
-Returns the `Number` index of the first element that satisfies the given `predicate`, otherwise `-1`. `predicate` which must accept an `A`.
+Returns the `Number` index of the first element that satisfies the given `func`, otherwise `-1`. `func` must accept an `A`.
 
 **Example**
 ```
@@ -230,9 +230,9 @@ xtr.arrays.indexWhere([1, 2, 3, 4, 5], function(item) item * 3 < 10)
 
 <br/>
 ## indicesWhere
-`indicesWhere(arr: Array[A], predicate: Func[(A) => Boolean]): Array[Number]`
+`indicesWhere(arr: Array[A], func: Func[(A) => Boolean]): Array[Number]`
 
-Returns an `Array[Number]` with the indices of elements that satisfy the given `predicate`, which must accept an `A`.
+Returns an `Array[Number]` with the indices of elements that satisfy the given `func`, which must accept exactly one parameter, an `A`.
 
 **Example**
 ```
@@ -245,9 +245,9 @@ xtr.arrays.indicesWhere([1, 2, 3, 4, 5], function(item) item * 3 < 10)
 
 <br/>
 ## lastIndexWhere
-`lastIndexWhere(arr: Array[A], predicate: Func[(A) => Boolean]): Number`
+`lastIndexWhere(arr: Array[A], func: Func[(A) => Boolean]): Number`
 
-Returns the `Number` index of the last element in `arr` that satisfies the given `predicate`, otherwise `-1`. `predicate` which must accept an `A`.
+Returns the `Number` index of the last element in `arr` that satisfies the given `func`, otherwise `-1`. `func` must accept an `A`.
 
 **Example**
 ```
@@ -260,13 +260,13 @@ xtr.arrays.lastIndexWhere([1, 2, 3, 4, 5], function(item) item * 3 < 10)
 
 <br/>
 ## occurrencesBy
-`occurrencesBy(arr: Array[A], identity: Func[(A) => String]): Object[Number]`
+`occurrencesBy(arr: Array[A], func: Func[(A) => String|Number|Boolean|Null]): Object[Number]`
 
-Returns an `Object` with an entry for each unique identity of elements in `arr`. The value of each entry is the `Number` of elements in `arr` that produced such identity, using `identity`. `identity` must take an `A`. Entries appear in the order their identity was first produced.
+Returns an `Object` with an entry for each unique identity of elements in `arr`. The value of each entry is the `Number` of elements in `arr` that produced such identity, using `func`, which must take an `A`. Entries appear in the order their identity was first produced.
 
 **Example**
 ```
-xtr.arrays.occurrencesBy([1, 2, 3, 4, 5], function(item) if (item) < 4 then 'under4' else 'over4')
+xtr.arrays.occurrencesBy([1, 2, 3, 4, 5], function(item) if item < 4 then 'under4' else 'over4')
 ```
 **Result**
 ```
@@ -275,12 +275,12 @@ xtr.arrays.occurrencesBy([1, 2, 3, 4, 5], function(item) if (item) < 4 then 'und
 
 <br/>
 ## partition
-`partition(arr: Array[A], predicate: Func[(A) => Boolean]): Object[A]`
+`partition(arr: Array[A], func: Func[(A) => Boolean]): Object[Array[A]]`
 
 Returns an `Object` with two entries:
 
-- `pass` key with an `Array[A]` of the subset of elements in `arr` that satisfy the given `predicate`, which must take an `A`.
-- `fail` key with an `Array[A]` of the subset of elements in `arr` that fail the given `predicate`, which must take an `A`.
+- `pass` key with an `Array[A]` of the subset of elements in `arr` that satisfy the given `func`, which must take an `A`.
+- `fail` key with an `Array[A]` of the subset of elements in `arr` that fail the given `func`, which must take an `A`.
 
 **Example**
 ```
@@ -293,12 +293,12 @@ xtr.arrays.partition([1, 2, 3, 4, 5], function(item) item < 4)
 
 <br/>
 ## splitAt
-`splitAt(arr: Array[A], n: Number): Object[A]`
+`splitAt(array: Array[A], index: Number): Object[Array[A]]`
 
-Returns an `Object[A]` with two entries:
+Returns an `Object` with two entries:
 
-- `left` key with an `Array[A]` containing the elements of `arr` before the `n` element.
-- `right` key with an `Array[A]` containing the remaining elements of `arr`.
+- `left` key with an `Array[A]` containing the elements of `array` before the `index` element.
+- `right` key with an `Array[A]` containing the remaining elements of `array`.
 
 **Example**
 ```
@@ -310,10 +310,25 @@ xtr.arrays.splitAt([1, 2, 3, 4, 5], 3)
 ```
 
 <br/>
-## take
-`take(arr: Array[A], n: Number): Array[A]`
+## sumBy
+`sumBy(array: Array[A], func: Func[(A) => Number]): Number`
 
-Returns a new `Array` with the elements in `arry`, but only taking the first `n` elements.
+Returns the `Number` sum of the values obtained by applying the given `func` to every element in `array`. `func` must accept an `A` and return a `Number`.
+
+**Example**
+```
+xtr.arrays.sumBy([{ price: 3 }, { price: 12 }], function(item) item.price)
+```
+**Result**
+```
+15
+```
+
+<br/>
+## take
+`take(array: Array[A], index: Number): Array[A]`
+
+Returns a new `Array` with the elements in `array`, but only taking the first `index` elements.
 
 **Example**
 ```
@@ -326,9 +341,9 @@ xtr.arrays.take([1, 2, 3, 4, 5], 3)
 
 <br/>
 ## takeWhile
-`takeWhile(arr: Array[A], predicate: Func[(A) => Boolean]): Array[A]`
+`takeWhile(array: Array[A], func: Func[(A) => Boolean]): Array[A]`
 
-Returns a new `Array` with the elements in `arr`, but only taking the first elements that satisfy the given `predicate`, which must accept an `A`.
+Returns a new `Array` with the elements in `array`, but only taking the first elements that satisfy the given `func`, which must accept an `A`.
 
 **Example**
 ```
@@ -341,11 +356,11 @@ xtr.arrays.takeWhile([1, 2, 3, 4, 5], function(item) item * 2 < 9)
 
 <br/>
 ## unzip
-`unzip(arr: Array[Array[A]]): Array[Array[A]]`
+`unzip(array: Array[Array[A]]): Array[Array[A]]`
 
-Create n-number of `Arrays`, each containing the n-th element of every array in `arr`.
+Create n-number of `Arrays`, each containing the n-th element of every array in `array`.
 
-Returns a new `Array` of equal size to the shortest array in `arr`. Every n-th element in the result is an `Array` containing the n-th element the arrays in `arr`.
+Returns a new `Array` of equal size to the shortest array in `array`. Every n-th element in the result is an `Array` containing the n-th element of the arrays in `array`.
 
 **Example**
 ```
@@ -357,7 +372,7 @@ xtr.arrays.unzip([[1, 'x'], [2, 'y'], [3, 'z']])
 ```
 
 ## unzipAll
-`unzipAll(arr: Array[Array[A]], fill: B): Array[Array[A|B]]`
+`unzipAll(array: Array[Array[A]], fill: B): Array[Array[A|B]]`
 
 Create n-number of `Arrays`, each containing the n-th element of every array in `arr`, using a `fill` value for missing n-th elements.
 
@@ -374,9 +389,9 @@ xtr.arrays.unzipAll([[1, 'x'], [2], [3, 'z']], 'NA')
 
 <br/>
 ## zip
-`zip(arr1: Array[A], arr2: Array[B], arrN: Array[C]*): Array[Array[A|B|C]]`
+`zip(arr1: Array[A], arr2: Array[B], arr3: Array[C], arr4: Array[D], arr5: Array[E]): Array[Array[A|B|C|D|E]]`
 
-Combines corresponding elements of the given arrays.
+Combines corresponding elements of the given arrays. Accepts two to five arrays; `arr3` through `arr5` are optional.
 
 Returns a new `Array` of equal size to the shortest array given. Every n-th element in the result is an `Array` containing the n-th element of the given arrays.
 
@@ -390,7 +405,7 @@ xtr.arrays.zip([1, 2, 3], ['x', 'y', 'z'])
 ```
 
 ## zipAll
-`zipAll(arr: Array[Array[A]], fill: B): Array[Array[A|B]]`
+`zipAll(array: Array[Array[A]], fill: B): Array[Array[A|B]]`
 
 Combines corresponding elements of the arrays in `arr`, using a `fill` value for short arrays.
 

--- a/docs/xtr/base64.md
+++ b/docs/xtr/base64.md
@@ -1,13 +1,13 @@
 # xtr.base64
 
 ## decode
-`decode(data: String): String`
+`decode(value: String | Number): String`
 
 Returns the Base64-decoded `data`.
 
 **Example**
 ```
-xtr.url.decode('SGVsbG8gV29ybGQ=')
+xtr.base64.decode('SGVsbG8gV29ybGQ=')
 ```
 **Result**
 ```
@@ -16,13 +16,13 @@ xtr.url.decode('SGVsbG8gV29ybGQ=')
 
 <br/>
 ## encode
-`encode(data: String): String`
+`encode(value: String | Number): String`
 
 Returns the Base64-encoded `data`.
 
 **Example**
 ```
-xtr.url.encode('Hello World')
+xtr.base64.encode('Hello World')
 ```
 **Result**
 ```

--- a/docs/xtr/crypto.md
+++ b/docs/xtr/crypto.md
@@ -3,11 +3,11 @@
 [//]: # (todo: document available algorithms or point to the docs)
 
 ## decrypt
-`decrypt(data: String, key: String, transformation: String): String`
+`decrypt(value: String, secret: String, algorithm: String): String`
 
-Decrypts the Base64 `data` with specified Java Cryptographic `transformation` and the given `key`.
+Decrypts the Base64 `value` with the specified Java Cryptographic transformation given in `algorithm`, using the given `secret`.
 
-The `transformation` must include the name of a cryptographic algorithm (e.g., AES), and may be followed by a feedback mode and padding scheme. A transformation is of the form: 'algorithm/mode/padding' or 'algorithm'. See the [Java Cipher](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/javax/crypto/Cipher.html) docs for more information.
+The `algorithm` transformation must include the name of a cryptographic algorithm (e.g., AES), and may be followed by a feedback mode and padding scheme. A transformation is of the form: 'algorithm/mode/padding' or 'algorithm'. See the [Java Cipher](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/javax/crypto/Cipher.html) docs for more information.
 
 **Example**
 ```
@@ -22,17 +22,17 @@ xtr.crypto.decrypt('vAkb3PWJPQF1kGkM3vQrdQ==', '$sixteencharkey$', 'AES/ECB/PKCS
 	xtrasonnet supports decryption through the Java Cryptographic Extension (JCE) framework. Every Java distribution is required to support a specific set of algorithms, while others may only be supported by third party libraries such as the popular [Bouncy Castle](https://www.bouncycastle.org/java.html) libraries, which are bundled with xtrasonnet.
 
 !!! note
-	In order to facilitate encryption/decryption, xtrasonnet prefixes the encrypted data with the randomly generated initialization vector (IV) used by the JCE Cipher. Similarly, decryption operations expect such IV to be present in order to correctly decrypt the data.  
+	In order to facilitate encryption/decryption, for every mode except ECB, xtrasonnet prefixes the encrypted data with the randomly generated initialization vector (IV) used by the JCE Cipher. Similarly, decryption operations expect such IV to be present in order to correctly decrypt the data. ECB transformations, like the one in the example above, use no IV and no prefix; a transformation with no explicit mode, e.g. plain 'AES', does get the IV prefix.  
 
     The form of the payload byte array expected for decryption is as follows: `[{encryption IV bytes},{encrypted data bytes}]` where the size of the IV portion is equal to the block size for the selected algorithm.
 
 <br/>
 ## encrypt
-`encrypt(data: String, key: String, transformation: String): String`
+`encrypt(value: String, secret: String, algorithm: String): String`
 
-Encrypts the `data` with specified Java Cryptographic `transformation` and the given `key`, and encodes the result in Base64.
+Encrypts the `value` with the specified Java Cryptographic transformation given in `algorithm`, using the given `secret`, and encodes the result in Base64.
 
-The `transformation` must include the name of a cryptographic algorithm (e.g., AES), and may be followed by a feedback mode and padding scheme. A transformation is of the form: 'algorithm/mode/padding' or 'algorithm'. See the [Java Cipher](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/javax/crypto/Cipher.html) docs for more information.
+The `algorithm` transformation must include the name of a cryptographic algorithm (e.g., AES), and may be followed by a feedback mode and padding scheme. A transformation is of the form: 'algorithm/mode/padding' or 'algorithm'. See the [Java Cipher](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/javax/crypto/Cipher.html) docs for more information.
 
 **Example**
 ```
@@ -47,15 +47,15 @@ xtr.crypto.encrypt('Hello, world!', '$sixteencharkey$', 'AES/ECB/PKCS5Padding')
 	xtrasonnet supports encryption through the Java Cryptographic Extension (JCE) framework. Every Java distribution is required to support a specific set of algorithms, while others may only be found in third party libraries such as the popular [Bouncy Castle](https://www.bouncycastle.org/java.html) libraries, which are bundled with xtrasonnet.
 
 !!! note
-	In order to facilitate encryption/decryption, xtrasonnet prefixes the encrypted data with the randomly generated initialization vector (IV) used by the JCE Cipher. Similarly decryption operations expect such IV to be present in order to correctly decrypt the data.  
+	In order to facilitate encryption/decryption, for every mode except ECB, xtrasonnet prefixes the encrypted data with the randomly generated initialization vector (IV) used by the JCE Cipher. Similarly decryption operations expect such IV to be present in order to correctly decrypt the data. ECB transformations, like the one in the example above, use no IV and no prefix; a transformation with no explicit mode, e.g. plain 'AES', does get the IV prefix.  
 
     The form of the encrypted byte array payload is as follows: `[{random IV bytes},{encrypted data bytes}]` where the size of the IV portion is equal to the block size for the selected algorithm.
 
 <br/>
 ## hash
-`hash(data: String, algorithm: String): String`
+`hash(value: String, algorithm: String): String`
 
-Calculates Message Digest for the `data` using the given hash `algorithm`, and encodes the result in a hexadecimal string.
+Calculates Message Digest for the `value` using the given hash `algorithm`, and encodes the result in a hexadecimal string.
 
 **Example**
 ```
@@ -72,9 +72,9 @@ xtr.crypto.hash('HelloWorld', 'MD5')
 
 <br/>
 ## hmac
-`hmac(data: String, key: String, algorithm: String): String`
+`hmac(value: String, secret: String, algorithm: String): String`
 
-Calculates the Message Authentication Code for the `data` using the given cryptographic hash `algorithm`, and encodes the result in a hexadecimal string.
+Calculates the Message Authentication Code for the `value` using the given cryptographic hash `algorithm` and `secret`, and encodes the result in a hexadecimal string.
 
 **Example**
 ```

--- a/docs/xtr/datetime.md
+++ b/docs/xtr/datetime.md
@@ -53,7 +53,7 @@ xtr.datetime.atBeginningOfMonth('2020-12-31T23:19:35Z')
 ## atBeginningOfWeek
 `atBeginningOfWeek(datetime: String): String`
 
-Returns the given `datetime` with the day set to first of the current week, and the time set to midnight.
+Returns the given `datetime` with the day set to first of the current week, and the time set to midnight. The week is taken to start on Sunday.
 
 **Example**
 ```
@@ -96,15 +96,15 @@ xtr.datetime.inOffset('2020-12-31T23:19:35Z', '-08:00')
 
 <br/>
 ## compare
-`compare(datetime1: String, datetime2: String): String`
+`compare(datetime: String, datetwo: String): Number`
 
 Returns:
 
-`1` if `datetime1` is after `datetime2`
+`1` if `datetime` is after `datetwo`
 
-`-1` if `datetime1` is before `datetime2`
+`-1` if `datetime` is before `datetwo`
 
-`0` if `datetime1` and `datetime2` are the same
+`0` if `datetime` and `datetwo` are the same
 
 **Example**
 ```
@@ -117,19 +117,20 @@ xtr.datetime.compare('2020-12-31T23:19:35Z','2020-01-01T00:00:00Z')
 
 <br/>
 ## of
-`of(parts: Object[Number|String]): String`
+`of(obj: Object[Number|String]): String`
 
-Returns the `String` representation of the date and time given in `parts`, an `Object` of the form:
+Returns the `String` representation of the date and time given in `obj`, an `Object` of the form:
 
 ```
 {
     year: Number, month: Number, day: Number,
     hour: Number, minute: Number, second: Number,
-    offset: String
+    nanosecond: Number, offset: String
 }
 ```
 
-where all elements are optional.
+where all elements are optional; keys outside this form are an error, except `dayOfWeek`, which is
+accepted and ignored so that `of(toParts(x))` round-trips.
 
 **Example**
 ```
@@ -147,7 +148,7 @@ xtr.datetime.of(parts)
 
 <br/>
 ## between
-`between(datetime1: String, datetime2: String): String`
+`between(datetimeone: String, datetimetwo: String): String`
 
 Returns the ISO-8601 duration between `datetime1` and `datetime2`.
 
@@ -165,7 +166,7 @@ xtr.datetime.between(date1, date2)
 
 <br/>
 ## format
-`format(datetime: String, format: String): String`
+`format(datetime: String, outputFormat: String): String`
 
 Returns the given `datetime` formatted in the requested `format`.
 
@@ -180,7 +181,7 @@ xtr.datetime.format('2019-09-20T18:53:41.425Z', 'yyyy/MM/dd')
 
 <br/>
 ## isLeapYear
-`isLeapYear(datetime: String): String`
+`isLeapYear(datetime: String): Boolean`
 
 Returns a `true` if `datetime` is in a leap year, otherwise `false`.
 
@@ -225,7 +226,7 @@ xtr.datetime.now()
 
 <br/>
 ## parse
-`parse(datetime: String|Number, format: String): String`
+`parse(datetime: String|Number, inputFormat: String): String`
 
 Returns an ISO-8601 extended offset date-time from the given `datetime` using the specified `format`.
 
@@ -290,7 +291,7 @@ xtr.datetime.toLocalDateTime('2019-07-04T21:00:00Z')
 
 <br/>
 ## toLocalTime
-`toLocalTime(datetime: String, format: String): String`
+`toLocalTime(datetime: String): String`
 
 Returns the given `datetime` without date or offset.
 
@@ -341,7 +342,7 @@ Returns the current day at midnight.
 
 **Example**
 ```
-xtr.datetime.today
+xtr.datetime.today()
 ```
 
 **Result**
@@ -357,7 +358,7 @@ Returns the next day at midnight.
 
 **Example**
 ```
-xtr.datetime.tomorrow
+xtr.datetime.tomorrow()
 ```
 
 **Result**
@@ -373,7 +374,7 @@ Returns the previous day at midnight.
 
 **Example**
 ```
-xtr.datetime.yesterday
+xtr.datetime.yesterday()
 ```
 
 **Result**

--- a/docs/xtr/datetime.md
+++ b/docs/xtr/datetime.md
@@ -199,6 +199,8 @@ false
 `minus(datetime: String, duration: String): String`
 
 Returns the result of subtracting the specified ISO-8601 `duration` from the given `datetime`.
+Accepts any duration `xtr.duration.of` can produce, including time-only forms like `'PT2H'`;
+a leading minus sign negates every part of the duration.
 
 **Example**
 ```
@@ -249,6 +251,8 @@ Additionally, developers can parse Unix timestamps by passing `'unix'` as the `f
 `plus(datetime: String, duration: String): String`
 
 Returns the result of adding the specified ISO-8601 `duration` to the given `datetime`.
+Accepts any duration `xtr.duration.of` can produce, including time-only forms like `'PT2H'`;
+a leading minus sign negates every part of the duration.
 
 **Example**
 ```

--- a/docs/xtr/duration.md
+++ b/docs/xtr/duration.md
@@ -14,7 +14,9 @@ Returns the ISO-8601 duration of the given `parts`, an `Object` of the form:
 }
 ```
 
-where all elements are optional.
+where all elements are optional and default to zero; keys outside this form are an error. The
+result is in canonical form: zero-valued parts are omitted, e.g. `{hours: 2}` yields `'PT2H'`,
+and all-zero parts yield `'PT0S'`.
 
 **Example**
 ```
@@ -42,6 +44,9 @@ Returns the constituent parts of the given `duration`, as an `Object` of the for
     hours: Number, minutes: Number, seconds: Number
 }
 ```
+
+All six parts are always present. Time-only durations like `'PT4H'` and negative durations like
+`'-P1DT2H'` are supported; a leading minus sign negates every part.
 
 **Example**
 ```

--- a/docs/xtr/duration.md
+++ b/docs/xtr/duration.md
@@ -15,8 +15,9 @@ Returns the ISO-8601 duration of the given `obj`, an `Object` of the form:
 ```
 
 where all elements are optional and default to zero; keys outside this form are an error. The
-result is in canonical form: zero-valued parts are omitted, e.g. `{hours: 2}` yields `'PT2H'`,
-and all-zero parts yield `'PT0S'`.
+`seconds` part may be fractional (`{seconds: 1.5}` yields `'PT1.5S'`); every other part must be
+a whole number. The result is in canonical form: zero-valued parts are omitted, e.g. `{hours: 2}`
+yields `'PT2H'`, and all-zero parts yield `'PT0S'`.
 
 **Example**
 ```
@@ -46,7 +47,8 @@ Returns the constituent parts of the given `str` duration, as an `Object` of the
 ```
 
 All six parts are always present. Time-only durations like `'PT4H'` and negative durations like
-`'-P1DT2H'` are supported; a leading minus sign negates every part.
+`'-P1DT2H'` are supported; a leading minus sign negates every part. Fractional seconds are kept
+exactly: `toParts('PT1.5S')` yields `seconds: 1.5`.
 
 **Example**
 ```

--- a/docs/xtr/duration.md
+++ b/docs/xtr/duration.md
@@ -3,9 +3,9 @@
 The duration module leverages the [ISO-8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) format.
 
 ## of
-`of(parts: Object[Number]): String`
+`of(obj: Object[Number]): String`
 
-Returns the ISO-8601 duration of the given `parts`, an `Object` of the form:
+Returns the ISO-8601 duration of the given `obj`, an `Object` of the form:
 
 ```
 {
@@ -34,9 +34,9 @@ xtr.duration.of(parts)
 
 <br/>
 ## toParts
-`toParts(duration: String): Object[Number]`
+`toParts(str: String): Object[Number]`
 
-Returns the constituent parts of the given `duration`, as an `Object` of the form:
+Returns the constituent parts of the given `str` duration, as an `Object` of the form:
 
 ```
 {

--- a/docs/xtr/index.md
+++ b/docs/xtr/index.md
@@ -2,7 +2,7 @@
 
 ## contains
 ### Array contains
-`contains(arr: Array, value: Any): Boolean`
+`contains(container: Array, value: Any): Boolean`
 
 Returns `true` if `arr` contains the given `value`, otherwise `false`.
 
@@ -17,7 +17,7 @@ true
 
 <br/>
 ### String contains
-`contains(str1: String, str2: String): Boolean`
+`contains(container: String, value: String): Boolean`
 
 Returns `true` if `str1` contains `str2`, otherwise `false`.
 
@@ -32,7 +32,7 @@ true
 
 <br/>
 ## endsWith
-`endsWith(str1: String, str2: String): String`
+`endsWith(main: String, sub: String): Boolean`
 
 Returns `true` if `str1` ends with `str2`, otherwise `false`.
 
@@ -72,9 +72,9 @@ xtr.entries({ scala: '3.1.3', java: '19' })
 <br/>
 ## filter
 ### filter func(value)
-`filter(arr: Array[A], predicate Func[(A) => Boolean]): Array[A]`
+`filter(array: Array[A], func: Func[(A) => Boolean]): Array[A]`
 
-Returns a new `Array[A]` containing the elements of `arr` that satisfy the given `predicate`, which must accept an `A` value to test.
+Returns a new `Array[A]` containing the elements of `array` that satisfy the given `func`, which must accept an `A` value to test.
 
 **Example**
 ```
@@ -87,9 +87,9 @@ xtr.filter([1, 2, 3, 4], function(item) item < 3)
 
 <br/>
 ### filter func(value, idx)
-`filter(arr: Array[A], predicate Func[(A, Number) => Boolean]): Array[A]`
+`filter(array: Array[A], func: Func[(A, Number) => Boolean]): Array[A]`
 
-Returns a new `Array[A]` containing the elements of `arr` that satisfy the given `predicate`, which must accept an `A` value and its `Number` index to test.
+Returns a new `Array[A]` containing the elements of `array` that satisfy the given `func`, which must accept an `A` value and its `Number` index to test.
 
 **Example**
 ```
@@ -102,7 +102,7 @@ xtr.filter([1, 2, 3, 4], function(item, idx) idx > 2)
 
 <br/>
 ## filterNotEq
-`filterNotEq(arr: Array[A], value: B): Array[A]`
+`filterNotEq(collection: Array[A], value: B): Array[A]`
 
 Returns a new `Array[A]` containing the elements of `arr` that are not equal to the given `value`.
 
@@ -117,9 +117,9 @@ xtr.filterNotEq([1, 2, 3, 4, 3, 4], 3)
 
 <br/>
 ## filterNotIn
-`filterNotIn(arr: Array[A], arr2: Array[B]): Array[A]`
+`filterNotIn(first: Array[A], second: Array[B]): Array[A]`
 
-Returns a new `Array[A]` containing the elements of `arr1` that are not in the given `arr2`.
+Returns a new `Array[A]` containing the elements of `first` that are not in the given `second`. `first` may also be an `Object`, in which case the entries whose keys are listed in `second` are removed.
 
 **Example**
 ```
@@ -133,9 +133,9 @@ xtr.filterNotIn([1, 2, 3, 4, 3, 4], [3, 4])
 <br/>
 ## filterObject
 ### filterObject func(value)
-`filterObject(obj: Object[A], predicate: Func[(A) => Boolean]): Object[A]`
+`filterObject(array: Object[A], func: Func[(A) => Boolean]): Object[A]`
 
-Returns a new `Object[A]` containing the entries of `obj` that satisfy the given `predicate`, which must accept an `A` value to test.
+Returns a new `Object[A]` containing the entries of `array` that satisfy the given `func`, which must accept an `A` value to test.
 
 **Example**
 ```
@@ -157,9 +157,9 @@ xtr.filterObject(languages, function(lang) lang.isJvm)
 
 <br/>
 ### filterObject func(value, key)
-`filterObject(obj: Object[A], predicate: Func[(A, String) => Boolean]): Object[A]`
+`filterObject(array: Object[A], func: Func[(A, String) => Boolean]): Object[A]`
 
-Returns a new `Object[A]` containing the entries of `obj` that satisfy the given `predicate`, which must accept an `A` value and its corresponding `String` key to test.
+Returns a new `Object[A]` containing the entries of `array` that satisfy the given `func`, which must accept an `A` value and its corresponding `String` key to test.
 
 **Example**
 ```
@@ -181,9 +181,9 @@ xtr.filterObject(languages, function(lang, name) !lang.isJvm || name == 'scala')
 
 <br/>
 ### filterObject func(value, key, idx)
-`filterObject(obj: Object[A], predicate: Func[(A, String, Number) => Boolean]): Object[A]`
+`filterObject(array: Object[A], func: Func[(A, String, Number) => Boolean]): Object[A]`
 
-Returns a new `Object[A]` containing the entries of `obj` that satisfy the given `predicate`, which must accept an `A` value and its corresponding `String` key and `Number` index to test.
+Returns a new `Object[A]` containing the entries of `array` that satisfy the given `func`, which must accept an `A` value and its corresponding `String` key and `Number` index to test.
 
 **Example**
 ```
@@ -206,9 +206,9 @@ xtr.filterObject(languages, function(lang, name, idx) idx == 0 || name == 'pytho
 <br/>
 ## flatMap
 ### flatMap func(value)
-`flatMap(arr: Array[A], function: Func[(A) => Array[B]]): Array[B]`
+`flatMap(array: Array[A], func: Func[(A) => Array[B]]): Array[B]`
 
-Returns a new `Array[B]` containing the elements of every `Array[B]` obtained by applying the given `function` to all elements in `arr`. `function` must accept an `A` value.
+Returns a new `Array[B]` containing the elements of every `Array[B]` obtained by applying the given `func` to all elements in `array`. `func` must accept an `A` value.
 
 **Example**
 ```
@@ -221,9 +221,9 @@ xtr.flatMap([1, 3, 5], function(item) [item, item * item])
 
 <br/>
 ### flatMap func(value, idx)
-`flatMap(arr: Array[A], function: Func[(A, Number) => Array[B]]): Array[B]`
+`flatMap(array: Array[A], func: Func[(A, Number) => Array[B]]): Array[B]`
 
-Returns a new `Array[B]` containing the elements of every `Array[B]` obtained by applying the given `function` to all elements in `arr`. `function` must accept an `A` value and its `Number` index.
+Returns a new `Array[B]` containing the elements of every `Array[B]` obtained by applying the given `func` to all elements in `array`. `func` must accept an `A` value and its `Number` index.
 
 **Example**
 ```
@@ -237,9 +237,9 @@ xtr.flatMap([1, 3, 5], function(item, idx) [item, item * idx])
 <br/>
 ## flatMapObject
 ### flatMapObject func(value)
-`flatMapObject(obj: Object[A], function: Func[(A) => Object[B]]): Object[B]`
+`flatMapObject(value: Object[A], func: Func[(A) => Object[B]]): Object[B]`
 
-Returns a new `Object[B]` containing the entries of every `Object[B]` obtained by applying the given `function` to all entries in `obj`. `function` must accept an `A` value.
+Returns a new `Object[B]` containing the entries of every `Object[B]` obtained by applying the given `func` to all entries in `value`. `func` must accept an `A` value.
 
 **Example**
 ```
@@ -270,9 +270,9 @@ xtr.flatMapObject(candidateReqs, reqsWeight)
 
 <br/>
 ### flatMapObject func(value, key)
-`flatMapObject(obj: Object[A], function: Func[(A, String) => Object[B]]): Object[B]`
+`flatMapObject(value: Object[A], func: Func[(A, String) => Object[B]]): Object[B]`
 
-Returns a new `Object[B]` containing the entries of every `Object[B]` obtained by applying the given `function` to all entries in `obj`. `function` must accept an `A` value and its corresponding `String` key.
+Returns a new `Object[B]` containing the entries of every `Object[B]` obtained by applying the given `func` to all entries in `value`. `func` must accept an `A` value and its corresponding `String` key.
 
 **Example**
 ```
@@ -303,9 +303,9 @@ xtr.flatMapObject(candidateReqs, reqsWeight)
 
 <br/>
 ### flatMapObject func(value, key, idx)
-`flatMapObject(obj: Object[A], function: Func[(A, String, Number) => Object[B]]): Object[B]`
+`flatMapObject(value: Object[A], func: Func[(A, String, Number) => Object[B]]): Object[B]`
 
-Returns a new `Object[B]` containing the entries of every `Object[B]` obtained by applying the given `function` to all entries in `obj`. `function` must accept an `A` value and its corresponding `String` key and `Number` index.
+Returns a new `Object[B]` containing the entries of every `Object[B]` obtained by applying the given `func` to all entries in `value`. `func` must accept an `A` value and its corresponding `String` key and `Number` index.
 
 **Example**
 ```
@@ -336,7 +336,7 @@ xtr.flatMapObject(candidateReqs, reqsWeight)
 
 <br/>
 ## flatten
-`flatten(arr: Array[Array[A]]): Array[A]`
+`flatten(array: Array[Array[A]]): Array[A]`
 
 Returns a new `Array[A]` containing the elements of every `Array[A]` in `arr`.
 
@@ -351,11 +351,11 @@ xtr.flatten([[1, 2], [3]])
 
 <br/>
 ## foldLeft
-`foldLeft(arr: Array[A], initValue: Any, function: Func[(A, Any) => Any]): Any`
+`foldLeft(arr: Array[A], init: Any, func: Func[(A, Any) => Any]): Any`
 
-From left to right in `arr`, applies the given `function` to the first element with `initValue`, then applies it to every subsequent element with the result of the previous invocation. `function` must accept an `A` value and `Any` value, which is `initValue` for the first invocation, and the result of the previous one for all others.
+From left to right in `arr`, applies the given `func` to the first element with `init`, then applies it to every subsequent element with the result of the previous invocation. `func` must accept an `A` value and `Any` value, which is `init` for the first invocation, and the result of the previous one for all others.
 
-Returns the `Any` result of the final `function` invocation.
+Returns the `Any` result of the final `func` invocation.
 
 !!! hint
     `fold` functions usually mutate the "accumulator" value on each invocation, thus "folding" the collection into a single value.
@@ -371,11 +371,11 @@ xtr.foldLeft([1, 2, 3], 0, function(item, acc) item + acc)
 
 <br/>
 ## foldRight
-`foldRight(arr: Array[A], initValue: Any, Func[(A, Any) => Any]): Any`
+`foldRight(arr: Array[A], init: Any, func: Func[(A, Any) => Any]): Any`
 
-From right to left in `arr`, applies the given `function` to the first element with `initValue`, then applies it to every subsequent element with the result of the previous invocation. `function` must accept an `A` value and `Any` value, which is `initValue` for the first invocation, and the result of the previous one for all others.
+From right to left in `arr`, applies the given `func` to the first element with `init`, then applies it to every subsequent element with the result of the previous invocation. `func` must accept an `A` value and `Any` value, which is `init` for the first invocation, and the result of the previous one for all others.
 
-Returns the `Any` result of the final `function` invocation.
+Returns the `Any` result of the final `func` invocation.
 
 !!! hint
     `fold` functions usually mutate the "accumulator" value on each invocation, thus "folding" the collection into a single value.
@@ -392,9 +392,9 @@ xtr.foldRight(['Lorem', 'ipsum', 'dolor'], '', function(item, acc) acc + ' ' + i
 <br/>
 ## groupBy
 ### Array groupBy func(value)
-`groupBy(arr: Array[A], Func[(A) => String]): Object[Array[A]]`
+`groupBy(container: Array[A], func: Func[(A) => String]): Object[Array[A]]`
 
-Returns an `Object[Array[A]]` where the keys are the results of applying the given `function` to all elements in `arr`, and their corresponding values are the `arr` elements for which the `function` invocation resulted in such key. `function` must accept an `A` value.
+Returns an `Object[Array[A]]` where the keys are the results of applying the given `func` to all elements in `container`, and their corresponding values are the `container` elements for which the `func` invocation resulted in such key. `func` must accept an `A` value.
 
 **Example**
 ```
@@ -419,9 +419,9 @@ xtr.groupBy(languages, function(lang) if lang.isJvm then 'jvmLangs' else 'others
 
 <br/>
 ### Array groupBy func(value, idx)
-`groupBy(arr: Array[A], Func[(A, Number) => String]): Object[Array[A]]`
+`groupBy(container: Array[A], func: Func[(A, Number) => String]): Object[Array[A]]`
 
-Returns an `Object[Array[A]]` where the keys are the results of applying the given `function` to all elements in `arr`, and their corresponding values are the `arr` elements for which the `function` invocation resulted in such key. `function` must accept an `A` value and its `Number` index.
+Returns an `Object[Array[A]]` where the keys are the results of applying the given `func` to all elements in `container`, and their corresponding values are the `container` elements for which the `func` invocation resulted in such key. `func` must accept an `A` value and its `Number` index.
 
 **Example**
 ```
@@ -447,9 +447,9 @@ xtr.groupBy(languages, langFunc)
 
 <br/>
 ### Object groupBy func(value)
-`groupBy(obj: Object[A], Func[(A) => String]): Object[Object[A]]`
+`groupBy(container: Object[A], func: Func[(A) => String]): Object[Object[A]]`
 
-Returns an `Object[Object[A]]` where the keys are the results of applying the given `function` to all elements in `arr`, and their corresponding values are the `arr` elements for which the `function` invocation resulted in such key. `function` must accept an `A` value.
+Returns an `Object[Object[A]]` where the keys are the results of applying the given `func` to all elements in `container`, and their corresponding values are the `container` elements for which the `func` invocation resulted in such key. `func` must accept an `A` value.
 
 **Example**
 ```
@@ -474,9 +474,9 @@ xtr.groupBy(languages, function(lang) if lang.isJvm then 'jvmLangs' else 'others
 
 <br/>
 ### Object groupBy func(value, key)
-`groupBy(obj: Object[A], Func[(A, String) => String]): Object[Object[A]]`
+`groupBy(container: Object[A], func: Func[(A, String) => String]): Object[Object[A]]`
 
-Returns an `Object[Object[A]]` where the keys are the results of applying the given `function` to all elements in `arr`, and their corresponding values are the `arr` elements for which the `function` invocation resulted in such key.`function` must accept an `A` value and its corresponding `String` key.
+Returns an `Object[Object[A]]` where the keys are the results of applying the given `func` to all elements in `container`, and their corresponding values are the `container` elements for which the `func` invocation resulted in such key.`func` must accept an `A` value and its corresponding `String` key.
 
 **Example**
 ```
@@ -501,9 +501,40 @@ xtr.groupBy(languages, langFunc)
 ```
 
 <br/>
+## indexOf
+### Array indexOf
+`indexOf(container: Array, value: Any): Number`
+
+Returns the index of the first element in `container` equal to the given `value`, or `-1` if there is none.
+
+**Example**
+```
+xtr.indexOf([1, 2, 3, 2], 2)
+```
+**Result**
+```
+1
+```
+
+<br/>
+### String indexOf
+`indexOf(container: String, value: String): Number`
+
+Returns the index of the first occurrence of `value` in `container`, or `-1` if there is none.
+
+**Example**
+```
+xtr.indexOf('hello', 'l')
+```
+**Result**
+```
+2
+```
+
+<br/>
 ## indicesOf
 ### Array indicesOf
-`indicesOf(arr: Array, value: Any): Array[Number]`
+`indicesOf(container: Array, value: Any): Array[Number]`
 
 Returns an `Array[Number]` with the indices of the elements in `arr` that equal `value`.
 
@@ -518,7 +549,7 @@ xtr.indicesOf([1, 7, 3, 4, 7], 7)
 
 <br/>
 ### String indicesOf
-`indicesOf(str1: String, str2: String): Array[Number]`
+`indicesOf(container: String, value: String): Array[Number]`
 
 Returns an `Array[Number]` with the indices of the substrings in `str1` that equal `str2`.
 
@@ -533,7 +564,7 @@ xtr.indicesOf('lorem ipsum dolor', 'lo')
 
 <br/>
 ## isArray
-`isArray(value: Any): Boolean`
+`isArray(v: Any): Boolean`
 
 Returns `true` if `value` is an `Array`, otherwise `false`.
 
@@ -548,7 +579,7 @@ true
 
 <br/>
 ## isBlank
-`isBlank(str: String): Boolean`
+`isBlank(value: String): Boolean`
 
 Returns `true` if `str` is empty or contains whitespace characters only, otherwise `false`.
 
@@ -563,7 +594,7 @@ true
 
 <br/>
 ## isBoolean
-`isBoolean(value: Any): Boolean`
+`isBoolean(v: Any): Boolean`
 
 Returns `true` if `value` is a `Boolean`, otherwise `false`.
 
@@ -578,7 +609,7 @@ true
 
 <br/>
 ## isDecimal
-`isDecimal(num: Number): Boolean`
+`isDecimal(value: Number): Boolean`
 
 Returns `true` if `num` is a decimal, otherwise `false`.
 
@@ -594,7 +625,7 @@ true
 <br/>
 ## isEmpty
 ### Array isEmpty
-`isEmpty(arr: Array): Boolean`
+`isEmpty(container: Array): Boolean`
 
 Returns `true` if `arr` is empty, otherwise `false`.
 
@@ -609,7 +640,7 @@ true
 
 <br/>
 ### Object isEmpty
-`isEmpty(obj: Object): Boolean`
+`isEmpty(container: Object): Boolean`
 
 Returns `true` if `obj` is empty, otherwise `false`.
 
@@ -624,7 +655,7 @@ true
 
 <br/>
 ### String isEmpty
-`isEmpty(str: String): Boolean`
+`isEmpty(container: String): Boolean`
 
 Returns `true` if `str` is empty, otherwise `false`.
 
@@ -639,7 +670,7 @@ true
 
 <br/>
 ## isFunction
-`isFunction(value: Any): Boolean`
+`isFunction(v: Any): Boolean`
 
 Returns `true` if `value` is a `Function`, otherwise `false`.
 
@@ -656,7 +687,7 @@ true
 
 <br/>
 ## isInteger
-`isInteger(num: Number): Boolean`
+`isInteger(value: Number): Boolean`
 
 Returns `true` if `num` is an integer, otherwise `false`.
 
@@ -671,7 +702,7 @@ true
 
 <br/>
 ## isNumber
-`isNumber(value: Any): Boolean`
+`isNumber(v: Any): Boolean`
 
 Returns `true` if `value` is a `Number`, otherwise `false`.
 
@@ -686,7 +717,7 @@ true
 
 <br/>
 ## isObject
-`isObject(value: Any): Boolean`
+`isObject(v: Any): Boolean`
 
 Returns `true` if `value` is an `Object`, otherwise `false`.
 
@@ -701,7 +732,7 @@ true
 
 <br/>
 ## isString
-`isString(value: Any): Boolean`
+`isString(v: Any): Boolean`
 
 Returns `true` if `value` is a `String`, otherwise `false`.
 
@@ -717,9 +748,9 @@ true
 <br/>
 ## join
 ### Array[Number] join
-`join(arr: Array[Number], separator: String): String`
+`join(array: Array[Number], sep: String): String`
 
-Returns a new `String` composed of all the elements in `arr` separated by the `separator`.
+Returns a new `String` composed of all the elements in `array` separated by the `sep`.
 
 **Example**
 ```
@@ -732,9 +763,9 @@ xtr.join([0, 1, 1, 2, 3, 5, 8], ', ')
 
 <br/>
 ### Array[String] join
-`join(arr: Array[String], String): String`
+`join(array: Array[String], sep: String): String`
 
-Returns a new `String` composed of all the elements in `arr` separated by the `separator`.
+Returns a new `String` composed of all the elements in `array` separated by the `sep`.
 
 **Example**
 ```
@@ -758,6 +789,37 @@ xtr.keys({ scala: '3.1.3', java: '19' })
 **Result**
 ```
 ['scala', 'java']
+```
+
+<br/>
+## lastIndexOf
+### Array lastIndexOf
+`lastIndexOf(container: Array, value: Any): Number`
+
+Returns the index of the last element in `container` equal to the given `value`, or `-1` if there is none.
+
+**Example**
+```
+xtr.lastIndexOf([1, 2, 3, 2], 2)
+```
+**Result**
+```
+3
+```
+
+<br/>
+### String lastIndexOf
+`lastIndexOf(container: String, value: String): Number`
+
+Returns the index of the last occurrence of `value` in `container`, or `-1` if there is none.
+
+**Example**
+```
+xtr.lastIndexOf('hello', 'l')
+```
+**Result**
+```
+3
 ```
 
 <br/>
@@ -826,9 +888,9 @@ xtr.length('hello, world!')
 <br/>
 ## map
 ### map func(value)
-`map(arr: Array[A], function: Func[(A) => B]): Array[B]`
+`map(value: Array[A], func: Func[(A) => B]): Array[B]`
 
-Returns a new `Array[B]` with the results of applying `function` to all elements in `arr`. `function` must accept an `A`.
+Returns a new `Array[B]` with the results of applying `func` to all elements in `value`. `func` must accept an `A`.
 
 **Example**
 ```
@@ -841,9 +903,9 @@ xtr.map([1, 2, 3, 4], function(item) item * item)
 
 <br/>
 ### map func(value, idx)
-`map(arr: Array[A], function: Func[(A, Number) => B]): Array[B]`
+`map(value: Array[A], func: Func[(A, Number) => B]): Array[B]`
 
-Returns a new `Array[B]` with the results of applying `function` to all elements in `arr`. `function` must accept an `A` and its `Number` index.
+Returns a new `Array[B]` with the results of applying `func` to all elements in `value`. `func` must accept an `A` and its `Number` index.
 
 **Example**
 ```
@@ -857,9 +919,9 @@ xtr.map([1, 2, 3, 4], function(item, idx) item * idx)
 <br/>
 ## mapEntries
 ### mapEntries func(value)
-`mapEntries(obj: Object[A], function: Func[(Object[A]) => B]): Array[B]`
+`mapEntries(value: Object[A], func: Func[(A) => B]): Array[B]`
 
-Returns an `Array[B]` with the results of applying `function` to all entries in `obj`. `function` must accept an `A`.
+Returns an `Array[B]` with the results of applying `func` to all entries in `value`. `func` must accept an `A`.
 
 **Example**
 ```
@@ -878,9 +940,9 @@ xtr.mapEntries(languages, function(lang) lang.project)
 
 <br/>
 ### mapEntries func(value, key)
-`mapEntries(obj: Object[A], function: Func[(Object[A], String) => B]): Array[B]`
+`mapEntries(value: Object[A], func: Func[(A, String) => B]): Array[B]`
 
-Returns an `Array[B]` with the results of applying `function` to all entries in `obj`. `function` must accept an `A` and its corresponding `String` key.
+Returns an `Array[B]` with the results of applying `func` to all entries in `value`. `func` must accept an `A` and its corresponding `String` key.
 
 **Example**
 ```
@@ -904,9 +966,9 @@ xtr.mapEntries(languages, function(lang, name) {
 
 <br/>
 ### mapEntries func(value, key, idx)
-`mapEntries(obj: Object[A], function: Func[(Object[A], String, Number) => B]): Array[B]`
+`mapEntries(value: Object[A], func: Func[(A, String, Number) => B]): Array[B]`
 
-Returns an `Array[B]` with the results of applying `function` to all entries in `obj`. `function` must accept an `A` and its corresponding `String` key and `Number` index.
+Returns an `Array[B]` with the results of applying `func` to all entries in `value`. `func` must accept an `A` and its corresponding `String` key and `Number` index.
 
 **Example**
 ```
@@ -929,26 +991,53 @@ xtr.mapEntries(languages, langFunc)
 <br/>
 ## mapObject
 ### mapObject func(value)
-`mapObject(obj: Object[A], function: Func[(A) => Object[B]]): Object[B]`
+`mapObject(value: Object[A], func: Func[(A) => Object[B]]): Object[B]`
 
-Returns a new Object[B] containing the entry of every Object[B] obtained by applying the given `function` to all entries in obj. `function` must accept an `A` value.
+Returns a new `Object[B]` containing the entry of every `Object[B]` obtained by applying the given `func` to all entries in `value`. `func` must accept an `A` value, and must return an `Object` with a single entry; returning an `Object` with more than one entry is an error.
+
+**Example**
+```
+xtr.mapObject({ scala: '3.1.3', java: '19' }, function(version) { [version]: true })
+```
+**Result**
+```
+{ '3.1.3': true, '19': true }
+```
 
 <br/>
 ### mapObject func(value, key)
-`mapObject(obj: Object[A], function: Func[(A, String) => Object[B]]): Object[B]`
+`mapObject(value: Object[A], func: Func[(A, String) => Object[B]]): Object[B]`
 
-Returns a new Object[B] containing the entry of every Object[B] obtained by applying the given `function` to all entries in obj. `function` must accept an `A` value and its corresponding `String` key.
+Returns a new `Object[B]` containing the entry of every `Object[B]` obtained by applying the given `func` to all entries in `value`. `func` must accept an `A` value and its corresponding `String` key, and must return an `Object` with a single entry.
+
+**Example**
+```
+xtr.mapObject({ scala: '3.1.3', java: '19' }, function(version, name) { [name]: 'v' + version })
+```
+**Result**
+```
+{ scala: 'v3.1.3', java: 'v19' }
+```
 
 <br/>
 ### mapObject func(value, key, idx)
-`mapObject(obj: Object[A], function: Func[(A, String, Number) => Object[B]]): Object[B]`
+`mapObject(value: Object[A], func: Func[(A, String, Number) => Object[B]]): Object[B]`
 
-Returns a new Object[B] containing the entry of every Object[B] obtained by applying the given `function` to all entries in obj. `function` must accept an `A` value and its corresponding `String` key and `Number` index.
+Returns a new `Object[B]` containing the entry of every `Object[B]` obtained by applying the given `func` to all entries in `value`. `func` must accept an `A` value and its corresponding `String` key and `Number` index, and must return an `Object` with a single entry.
+
+**Example**
+```
+xtr.mapObject({ scala: '3.1.3', java: '19' }, function(version, name, idx) { [name + idx]: version })
+```
+**Result**
+```
+{ scala0: '3.1.3', java1: '19' }
+```
 
 <br/>
 ## max
 ### Array[Boolean] max
-`max(arr: Array[Boolean]): Boolean`
+`max(array: Array[Boolean]): Boolean`
 
 Returns the max `Boolean` in `arr`, with `true` being "bigger" than `false`.
 
@@ -963,7 +1052,7 @@ true
 
 <br/>
 ### Array[Number] max
-`max(arr: Array[Number]): Number`
+`max(array: Array[Number]): Number`
 
 Returns the max `Number` in `arr`.
 
@@ -978,7 +1067,7 @@ xtr.max([0, 8, 2, 100])
 
 <br/>
 ### Array[String] max
-`max(arr: Array[String]): String`
+`max(array: Array[String]): String`
 
 Returns the max `String` in `arr`.
 
@@ -994,16 +1083,16 @@ xtr.max(['Lorem', 'zzz', 'ipsum', 'dolor'])
 <br/>
 ## maxBy
 ### maxBy func(_) => Boolean
-`maxBy(arr: Array[A], function: Func[(A) => Boolean]): Array[A]`
+`maxBy(array: Array[A], func: Func[(A) => Boolean]): A`
 
-Returns the max `A` by comparing the values returned by `function`, which must accept an `A`.
+Returns the max `A` by comparing the values returned by `func`, which must accept an `A`.
 
 **Example**
 ```
 local languages = [
     { name: 'java', version: '19', isPreferred: false },
-    { name: 'python', version: '3.1.14', isPreferred: false }
-    { name: 'scala', version: '3.1.3', isPreferred: true },
+    { name: 'python', version: '3.1.14', isPreferred: false },
+    { name: 'scala', version: '3.1.3', isPreferred: true }
 ];
 
 xtr.maxBy(languages, function(lang) lang.isPreferred)
@@ -1015,16 +1104,16 @@ xtr.maxBy(languages, function(lang) lang.isPreferred)
 
 <br/>
 ### maxBy func(_) => Number
-`maxBy(arr: Array[A], function: Func[(A) => Number]): Array[A]`
+`maxBy(array: Array[A], func: Func[(A) => Number]): A`
 
-Returns the max `A` by comparing the values returned by `function`, which must accept an `A`.
+Returns the max `A` by comparing the values returned by `func`, which must accept an `A`.
 
 **Example**
 ```
 local languages = [
     { name: 'java', version: '19', weight: 2 },
-    { name: 'python', version: '3.1.14', weight: 2 }
-    { name: 'scala', version: '3.1.3', weight: 4 },
+    { name: 'python', version: '3.1.14', weight: 2 },
+    { name: 'scala', version: '3.1.3', weight: 4 }
 ];
 
 xtr.maxBy(languages, function(lang) lang.weight)
@@ -1036,9 +1125,9 @@ xtr.maxBy(languages, function(lang) lang.weight)
 
 <br/>
 ### maxBy func(_) => String
-`maxBy(arr: Array[A], function: Func[(A) => String]): Array[A]`
+`maxBy(array: Array[A], func: Func[(A) => String]): A`
 
-Returns the max `A` by comparing the values returned by `function`, which must accept an `A`.
+Returns the max `A` by comparing the values returned by `func`, which must accept an `A`.
 
 **Example**
 ```
@@ -1058,7 +1147,7 @@ xtr.maxBy(languages, function(lang) lang.score)
 <br/>
 ## min
 ### Array[Boolean] min
-`min(arr: Array[Boolean]): Boolean`
+`min(array: Array[Boolean]): Boolean`
 
 Returns the min `Boolean` in `arr`, with `false` being "smaller" than `true`.
 
@@ -1073,7 +1162,7 @@ false
 
 <br/>
 ### Array[Number] min
-`min(arr: Array[Number]): Number`
+`min(array: Array[Number]): Number`
 
 Returns the min `Number` in `arr`.
 
@@ -1088,7 +1177,7 @@ xtr.min([0, 8, 2, 100])
 
 <br/>
 ### Array[String] min
-`min(arr: Array[String]): String`
+`min(array: Array[String]): String`
 
 Returns the min `String` in `arr`.
 
@@ -1104,9 +1193,9 @@ xtr.min(['Lorem', 'AAA', 'ipsum', 'dolor'])
 <br/>
 ## minBy
 ### minBy func(_) => Boolean
-`minBy(arr: Array[A], comparator: Func[(A) => Boolean]): Array[A]`
+`minBy(array: Array[A], func: Func[(A) => Boolean]): A`
 
-Returns the min `A` by comparing the values returned by `function`, which must accept an `A`.
+Returns the min `A` by comparing the values returned by `func`, which must accept an `A`.
 
 **Example**
 ```
@@ -1125,9 +1214,9 @@ xtr.minBy(languages, function(lang) lang.isPreferred)
 
 <br/>
 ### minBy func(_) => Number
-`minBy(arr: Array[A], comparator: Func[(A) => Number]): Array[A]`
+`minBy(array: Array[A], func: Func[(A) => Number]): A`
 
-Returns the min `A` by comparing the values returned by `function`, which must accept an `A`.
+Returns the min `A` by comparing the values returned by `func`, which must accept an `A`.
 
 **Example**
 ```
@@ -1146,9 +1235,9 @@ xtr.minBy(languages, function(lang) lang.weight)
 
 <br/>
 ### minBy func(_) => String
-`minBy(arr: Array[A], comparator: Func[(A) => String]): Array[A]`
+`minBy(array: Array[A], func: Func[(A) => String]): A`
 
-Returns the min `A` by comparing the values returned by `function`, which must accept an `A`.
+Returns the min `A` by comparing the values returned by `func`, which must accept an `A`.
 
 **Example**
 ```
@@ -1182,10 +1271,13 @@ Result
 
 <br/>
 ## sortBy
-### sortBy func(_) => Boolean
-`sortBy(arr: Array[A], Func[(A) => Boolean]): Array[A]`
 
-Returns a new `Array[A]` with the conents of `arr` sorted by comparing the values returned by `function`, which must accept and `A`.
+`sortBy` also accepts an `Object` as `value`, sorting its entries. In both cases `func` may take a second parameter: the element's `Number` index for arrays, or the entry's `String` key for objects.
+
+### sortBy func(_) => Boolean
+`sortBy(value: Array[A], func: Func[(A) => Boolean]): Array[A]`
+
+Returns a new `Array[A]` with the contents of `value` sorted by comparing the values returned by `func`, which must accept an `A`.
 
 **Example**
 ```
@@ -1195,7 +1287,7 @@ local languages = [
     { name: 'python', version: '3.1.14', isPreferred: false }
 ];
 
-xtr.minBy(languages, function(lang) lang.isPreferred)
+xtr.sortBy(languages, function(lang) lang.isPreferred)
 ```
 **Result**
 ```
@@ -1208,9 +1300,9 @@ xtr.minBy(languages, function(lang) lang.isPreferred)
 
 <br/>
 ### sortBy func(_) => Number
-`sortBy(arr: Array[A], Func[(A) => Number]): Array[A]`
+`sortBy(value: Array[A], func: Func[(A) => Number]): Array[A]`
 
-Returns a new `Array[A]` with the conents of `arr` sorted by comparing the values returned by `function`, which must accept and `A`.
+Returns a new `Array[A]` with the contents of `value` sorted by comparing the values returned by `func`, which must accept an `A`.
 
 **Example**
 ```
@@ -1233,9 +1325,9 @@ xtr.sortBy(languages, function(lang) lang.weight)
 
 <br/>
 ### sortBy func(_) => String
-`sortBy(arr: Array[A], Func[(A) => String]): Array[A]`
+`sortBy(value: Array[A], func: Func[(A) => String]): Array[A]`
 
-Returns a new `Array[A]` with the conents of `arr` sorted by comparing the values returned by `function`, which must accept and `A`.
+Returns a new `Array[A]` with the contents of `value` sorted by comparing the values returned by `func`, which must accept an `A`.
 
 **Example**
 ```
@@ -1258,7 +1350,7 @@ xtr.sortBy(languages, function(lang) lang.score)
 
 <br/>
 ## range
-`range(first: Number, last: Number): Array[Number]`
+`range(begin: Number, end: Number): Array[Number]`
 
 Returns an `Array[Number]` containing numbers from `first` to `last`.
 
@@ -1274,9 +1366,9 @@ xtr.range(1, 5)
 <br/>
 ## read
 ### read mediaType
-`read(data: String, mediaType: String): Any`
+`read(data: String, mimeType: String): Any`
 
-Parses the `data` as the given `mediaType` using the data format plugins available to the `Transformer`.
+Parses the `data` as the given `mimeType` using the data format plugins available to the `Transformer`.
 
 **Example**
 ```
@@ -1291,9 +1383,9 @@ xtr.read('<hello>world!</hello>', 'application/xml')
 
 <br/>
 ### read mediaType, params
-`read(data: String, mediaType: String, params: Object): Any`
+`read(data: String, mimeType: String, params: Object): Any`
 
-Parses the `data` as the given `mediaType` and `params` options using the data format plugins available to the `Transformer`.
+Parses the `data` as the given `mimeType` and `params` options using the data format plugins available to the `Transformer`.
 
 **Example**
 ```
@@ -1309,9 +1401,9 @@ xtr.read('<hello>world!</hello>', 'application/xml', { textkey: '_txt' })
 <br/>
 ## readUrl
 ### readUrl mediaType
-`readUrl(url: String, mediaType: String): Any`
+`readUrl(url: String, mimeType: String): Any`
 
-Retrieves the data at `url` and parses it as the given `mediaType`. Supported schemes/protocols are `http`, `https`, `classpath`, and `file`.
+Retrieves the data at `url` and parses it as the given `mimeType`. Supported schemes/protocols are `http`, `https`, `classpath`, and `file`.
 
 Asumming `example.com` returns `<hello>world!</hello>`:
 
@@ -1328,9 +1420,9 @@ xtr.readUrl('example.com/data', 'application/xml')
 
 <br/>
 ### readUrl mediaType, params
-`readUrl(url: String, mediaType: String, params: Object): Any`
+`readUrl(url: String, mimeType: String, params: Object): Any`
 
-Retrieves the data at `url` and parses it as the given `mediaType` with `params` options. Supported schemes/protocols are `http`, `https`, `classpath`, and `file`.
+Retrieves the data at `url` and parses it as the given `mimeType` with `params` options. Supported schemes/protocols are `http`, `https`, `classpath`, and `file`.
 
 Asumming `example.com` returns `<hello>world!</hello>`:
 
@@ -1347,9 +1439,9 @@ xtr.readUrl('example.com', 'application/xml', { textkey: '_txt' })
 
 <br/>
 ## rmKey
-`rmKey(obj: Object[A], key: String): Object[A]`
+`rmKey(collection: Object[A], value: String): Object[A]`
 
-Returns a new `Object[A]` containing the entries of `obj` minus the entry for the given `key`.
+Returns a new `Object[A]` containing the entries of `obj` minus the entry whose key equals the given `value`.
 
 **Example**
 ```
@@ -1362,7 +1454,7 @@ xtr.rmKey({ scala: '3.1.3', java: '19' }, 'java')
 
 <br/>
 ## rmKeyIn
-`rmKeyIn(obj: Object[A], arr: Array[String]): Object[A]`
+`rmKeyIn(first: Object[A], second: Array[String]): Object[A]`
 
 Returns a new `Object[A]` containing the entries of `obj` minus the entries whose key is in the given `arr`.
 
@@ -1377,9 +1469,9 @@ xtr.rmKeyIn({ scala: '3.1.3', java: '19' }, ['java', 'scala'])
 
 <br/>
 ## replace
-`replace(str1: String, str2: String, str3: String): String`
+`replace(str1: String, str2: String, replacement: String): String`
 
-Returns a new `String` with the contents of `str1`, with occurrences of `str2` replaced by `str3`.
+Returns a new `String` with the contents of `str1`, with occurrences of `str2` replaced by `replacement`.
 
 **Example**
 ```
@@ -1393,7 +1485,7 @@ xtr.replace('hello, world!', 'world', 'everyone')
 <br/>
 ## reverse
 ### Array reverse
-`reverse(arr: Array): Array`
+`reverse(collection: Array): Array`
 
 Returns a new `Array` with the elements of `arr` in reversed order.
 
@@ -1408,7 +1500,7 @@ xtr.reverse([1, 2, 3])
 
 <br/>
 ### Object reverse
-`reverse(obj: Object): Object`
+`reverse(collection: Object): Object`
 
 Returns a new `Object` with the entries of `obj` in reversed order.
 
@@ -1423,7 +1515,7 @@ xtr.reverse({ key1: 'value1', key2: 'value2' })
 
 <br/>
 ### String reverse
-`reverse(str: String): String`
+`reverse(collection: String): String`
 
 Returns a new `String` with the characters of `str` in reversed order.
 
@@ -1483,7 +1575,7 @@ xtr.toLowerCase('Hello World!')
 
 <br/>
 ## toString
-`toString(value: String|Number|Boolean|Null): String`
+`toString(value: Any): String`
 
 Returns the `String` representation of `value`.
 
@@ -1506,7 +1598,7 @@ Returns the `String` representation of `value`.
 
 <br/>
 ## toUpperCase
-`toUpperCase(String): String`
+`toUpperCase(str: String): String`
 
 Returns the uppercase representation of `str`.
 
@@ -1584,7 +1676,7 @@ xtr.uuid()
 ## values
 `values(obj: Object[A]): Array[A]`
 
-Returns an `Array[String]` containing all the values in `obj`.
+Returns an `Array[A]` containing all the values in `obj`.
 
 **Example**
 ```
@@ -1598,9 +1690,9 @@ xtr.values({ scala: '3.1.3', java: '19' })
 <br/>
 ## write
 ### write mediaType
-`write(data: Any, mediaType: String): String`
+`write(data: Any, mimeType: String): String`
 
-Writes the `data` in the given `mediaType` format using the data format plugins available to the `Transformer`.
+Writes the `data` in the given `mimeType` format using the data format plugins available to the `Transformer`.
 
 **Example**
 ```
@@ -1613,9 +1705,9 @@ xtr.write({ hello: 'world', arr: [], nil: null }, 'application/json')
 
 <br/>
 ### write mediaType, params
-`write(data: Any, mediaType: String, params: Object[): String`
+`write(data: Any, mimeType: String, params: Object): String`
 
-Writes the `data` in the given `mediaType` format and `params` options using the data format plugins available to the `Transformer`.
+Writes the `data` in the given `mimeType` format and `params` options using the data format plugins available to the `Transformer`.
 
 **Example**
 ```

--- a/docs/xtr/math.md
+++ b/docs/xtr/math.md
@@ -16,9 +16,9 @@ xtr.math.abs(-1)
 
 <br/>
 ## acos
-`acos(num: Number): Number`
+`acos(x: Number): Number`
 
-Returns the arc cosine of the given `num`.
+Returns the arc cosine of the given `x`.
 
 **Example**
 ```
@@ -31,9 +31,9 @@ xtr.math.acos(1)
 
 <br/>
 ## asin
-`asin(num: Number): Number`
+`asin(x: Number): Number`
 
-Returns the arc sine of the given `num`.
+Returns the arc sine of the given `x`.
 
 **Example**
 ```
@@ -46,9 +46,9 @@ xtr.math.asin(1)
 
 <br/>
 ## atan
-`atan(num: Number): Number`
+`atan(x: Number): Number`
 
-Returns the arc tangent of the given `num`.
+Returns the arc tangent of the given `x`.
 
 **Example**
 ```
@@ -61,9 +61,9 @@ xtr.math.atan(1)
 
 <br/>
 ## avg
-`avg(arr: Array[Number]): Number`
+`avg(array: Array[Number]): Number`
 
-Returns the average of the numbers in `arr`.
+Returns the average of the numbers in `array`.
 
 **Example**
 ```
@@ -91,9 +91,9 @@ xtr.math.ceil(1.01)
 
 <br/>
 ## clamp
-`clamp(num: Number, min: Number, max: Number): Number`
+`clamp(x: Number, minVal: Number, maxVal: Number): Number`
 
-Returns `num` if it exists between `min` and `max`, otherwise the one that is closest.
+Returns `x` if it exists between `minVal` and `maxVal`, otherwise the one that is closest.
 
 **Example**
 ```
@@ -106,9 +106,9 @@ xtr.math.clamp(100, 0, 10)
 
 <br/>
 ## cos
-`cos(num: Number): Number`
+`cos(x: Number): Number`
 
-Returns the cosine of the given`num`.
+Returns the cosine of the given `x`.
 
 **Example**
 ```
@@ -121,9 +121,9 @@ xtr.math.cos(0)
 
 <br/>
 ## exp
-`exp(num: Number): Number`
+`exp(x: Number): Number`
 
-Returns Euler's number e, to the power of `num`.
+Returns Euler's number e, to the power of `x`.
 
 **Example**
 ```
@@ -136,9 +136,9 @@ xtr.math.exp(2)
 
 <br/>
 ## exponent
-`exponent(num: Number): Number`
+`exponent(x: Number): Number`
 
-Returns the exponent portion of the double-precision binary floating-point representation (IEEE 754:binary64) of the given `num`.
+Returns the exponent portion of the double-precision binary floating-point representation (IEEE 754:binary64) of the given `x`.
 
 **Example**
 ```
@@ -166,9 +166,9 @@ xtr.math.floor(4.99)
 
 <br/>
 ## log
-`log(num: Number): Number`
+`log(x: Number): Number`
 
-Returns the natural logarithm of the given `num`.
+Returns the natural logarithm of the given `x`.
 
 **Example**
 ```
@@ -181,9 +181,9 @@ xtr.math.log(2)
 
 <br/>
 ## mantissa
-`mantissa(num: Number): Number`
+`mantissa(x: Number): Number`
 
-Returns the fraction portion (aka significand) of the double-precision binary floating-point representation (IEEE 754:binary64) of the given `num`.
+Returns the fraction portion (aka significand) of the double-precision binary floating-point representation (IEEE 754:binary64) of the given `x`.
 
 **Example**
 ```
@@ -196,7 +196,7 @@ xtr.math.mantissa(2)
 
 <br/>
 ## pow
-`pow(num: Number1, num: Number2)`
+`pow(num1: Number, num2: Number): Number`
 
 Returns the value of `num1` raised to the power of `num2`.
 
@@ -211,13 +211,13 @@ xtr.math.pow(2, 2)
 
 <br/>
 ## random
-`random`
+`random(): Number`
 
 Returns a pseudo-random double-precision floating-point number between `0` and `1`.
 
 **Example**
 ```
-xtr.math.random
+xtr.math.random()
 ```
 **Result**
 ```
@@ -228,7 +228,7 @@ xtr.math.random
 ## randomInt
 `randomInt(num: Number): Number`
 
-Returns a pseudo-random integer between 0 (inclusive) and the given`num` (exclusive).
+Returns a pseudo-random integer between 0 (inclusive) and the given `num` (exclusive). A `num` of zero or less is an error.
 
 **Example**
 ```
@@ -241,7 +241,7 @@ xtr.math.randomInt(500)
 
 <br/>
 ## round
-`round(num: Number, mode: String = 'half-up', precision: Number = '0'): Number`
+`round(num: Number, mode: String = 'half-up', precision: Number = 0): Number`
 
 Rounds the given `num` using the `mode` and `precision` requested. Supported modes are `up`, `down`, `half-up`, `half-down`, `ceiling`, `floor`, and `half-even`.
 
@@ -256,9 +256,9 @@ xtr.math.round(2.5)
 
 <br/>
 ## sin
-`sin(num: Number): Number`
+`sin(x: Number): Number`
 
-Returns the sine of the given `num`.
+Returns the sine of the given `x`.
 
 **Example**
 ```
@@ -286,9 +286,9 @@ xtr.math.sqrt(4)
 
 <br/>
 ## sum
-`sum(arr: Array[Number])`
+`sum(array: Array[Number]): Number`
 
-Returns the sum of all numbers in `arr`.
+Returns the sum of all numbers in `array`.
 
 **Example**
 ```
@@ -301,9 +301,9 @@ xtr.math.sum([10, 20, 30])
 
 <br/>
 ## tan
-`tan(num: Number): Number`
+`tan(x: Number): Number`
 
-Returns the tangent of the given `num`.
+Returns the tangent of the given `x`.
 
 **Example**
 ```

--- a/docs/xtr/numbers.md
+++ b/docs/xtr/numbers.md
@@ -1,9 +1,9 @@
 # xtr.numbers
 
 ## ofBinary
-`ofBinary(binary: String | Number): Number`
+`ofBinary(value: String | Number): Number`
 
-Returns the `Number` representation for the given `binary`.
+Returns the `Number` representation for the given binary `value`.
 
 **Example**
 ```
@@ -16,9 +16,9 @@ xtr.numbers.ofBinary(1100100)
 
 <br/>
 ## ofHex
-`ofHex(hexadecimal: String): Number`
+`ofHex(value: String | Number): Number`
 
-Returns the `Number` representation for the given `hexadecimal`.
+Returns the `Number` representation for the given hexadecimal `value`.
 
 **Example**
 ```
@@ -31,9 +31,9 @@ xtr.numbers.ofHex('F')
 
 <br/>
 ## ofOctal
-`ofOctal(octal: String | Number): Number`
+`ofOctal(str: String | Number): Number`
 
-Returns the `Number` representation for the given `octal`.
+Returns the `Number` representation for the given octal `str`.
 
 **Example**
 ```
@@ -46,13 +46,13 @@ xtr.numbers.ofOctal(107136)
 
 <br/>
 ## ofRadix
-`ofRadix(value: String | Number, n: Number): Number`
+`ofRadix(value: String | Number, num: Number): Number`
 
-Returns the `Number` representation for the given Base-`n` `value`
+Returns the `Number` representation for the given Base-`num` `value`. The radix must be between `2` and `36`.
 
 **Example**
 ```
-xtr.numbers.ofRadixNumber('10', 3)
+xtr.numbers.ofRadix('10', 3)
 ```
 **Result**
 ```
@@ -61,7 +61,7 @@ xtr.numbers.ofRadixNumber('10', 3)
 
 <br/>
 ## toBinary
-`toBinary(number: Number): String`
+`toBinary(value: Number | String): String`
 
 Returns the binary representation for the given `number`.
 
@@ -76,7 +76,7 @@ xtr.numbers.toBinary(100)
 
 <br/>
 ## toHex
-`toHex(number: Number): String`
+`toHex(value: Number | String): String`
 
 Returns the hexadecimal representation for the given `number`.
 
@@ -91,7 +91,7 @@ xtr.numbers.toHex(15)
 
 <br/>
 ## toOctal
-`toOctal(number: Number): String`
+`toOctal(value: Number | String): String`
 
 Returns the octal representation for the given `number`.
 
@@ -106,7 +106,7 @@ xtr.numbers.toOctal(36446)
 
 <br/>
 ## toRadix
-`toRadix(value: Number, n: Number): String`
+`toRadix(value: Number | String, num: Number): String`
 
 Returns the Base-`n` representation for the given `value` as a `String`.
 

--- a/docs/xtr/objects.md
+++ b/docs/xtr/objects.md
@@ -1,9 +1,9 @@
 # xtr.objects
 
 ## all
-`all(obj, Object[A], predicate: Func[(A, String) => Boolean]): Boolean`
+`all(value: Object[A], func: Func[(A, String) => Boolean]): Boolean`
 
-Returns `true` if all entries in `obj` satisfy the given `predicate`, otherwise `false`. `predicate` must accept an `A` and its corresponding `String` key.
+Returns `true` if all entries in `value` satisfy the given `func`, otherwise `false`. `func` must accept an `A` and its corresponding `String` key.
 
 **Example**
 ```
@@ -22,9 +22,9 @@ false
 
 <br/>
 ## any
-`any(obj, Object[A], predicate: Func[(A, String) => Boolean]): Boolean`
+`any(value: Object[A], func: Func[(A, String) => Boolean]): Boolean`
 
-Returns `true` if any entry in `obj` satisfies the given `predicate`, otherwise `false`. `predicate` must accept an `A` and its corresponding `String` key.
+Returns `true` if any entry in `value` satisfies the given `func`, otherwise `false`. `func` must accept an `A` and its corresponding `String` key.
 
 **Example**
 ```
@@ -44,9 +44,9 @@ true
 <br/>
 ## distinctBy
 ### distinctBy func(value)
-`distinctBy(obj: Object[A], Func[(A) => B]): Object[A]`
+`distinctBy(container: Object[A], func: Func[(A) => B]): Object[A]`
 
-Returns a new `Object` with the distinct entries in `obj` using the given `identity` function for comparison. `identity` must accept an `A`.
+Returns a new `Object` with the distinct entries in `container` using the given `func` function for comparison. `func` must accept an `A`.
 
 **Example**
 ```
@@ -68,9 +68,9 @@ xtr.objects.distinctBy(languages, function(lang) lang.name)
 
 <br/>
 ### distinctBy func(value, key)
-`distinctBy(obj: Object[A], Func[(A, String) => B]): Object[A]`
+`distinctBy(container: Object[A], func: Func[(A, String) => B]): Object[A]`
 
-Returns a new `Object` with the distinct entries in `obj` using the given `identity` function for comparison. `identity` must accept an `A` and its corresponding `String` key.
+Returns a new `Object` with the distinct entries in `container` using the given `func` function for comparison. `func` must accept an `A` and its corresponding `String` key.
 
 **Example**
 ```
@@ -80,9 +80,9 @@ local languages = {
     third: { name: 'java', version: '18', isJvm: true }
 };
 
-xtr.objects.distinctBy(languages, function(lang, ordinal)
+xtr.objects.distinctBy(languages, function(lang, key)
     if (lang.name == 'java') then lang.version
-    else ordinal
+    else key
 )
 ```
 **Result**
@@ -96,23 +96,57 @@ xtr.objects.distinctBy(languages, function(lang, ordinal)
 
 <br/>
 ## fromArray
-### fromArray func(value)
-`fromArray(arr: Array[A], Func[(A) => Object[B]): Object[B]`
+### fromArray
+`fromArray(arr: Array[A], keyF: Func[(A) => String]): Object[A]`
 
-Returns a new `Object[B]` containing the entry of every `Object[B]` obtained by applying the given `function` to all elements in `arr`. `function` must accept an `A` value.
+Returns a new `Object` with an entry for every element in `arr`, whose key is the result of applying the given `keyF` to the element, and whose value is the element itself. `keyF` must return a `String`; any other type is an error. `keyF` may instead accept two parameters, the element and its `Number` index. Elements that produce the same key keep only the last one.
+
+**Example**
+```
+local languages = [
+    { name: 'scala', version: '3.1.3' },
+    { name: 'java', version: '19' }
+];
+
+xtr.objects.fromArray(languages, function(lang) lang.name)
+```
+**Result**
+```
+{
+    scala: { name: 'scala', version: '3.1.3' },
+    java: { name: 'java', version: '19' }
+}
+```
 
 <br/>
-### fromArray func(value, idx)
-`fromArray(arr: Array[A], Func[(A, Number) => Object[B]]: Object[B]`
+### fromArray with valueF
+`fromArray(arr: Array[A], keyF: Func[(A) => String], valueF: Func[(A) => B]): Object[B]`
 
-Returns a new `Object[B]` containing the entry of every `Object[B]` obtained by applying the given `function` to all elements in `arr`. `function` must accept an `A` value and its `Number` index.
+Returns a new `Object` with an entry for every element in `arr`, whose key is the result of applying the given `keyF` to the element, and whose value is the result of applying the given `valueF` to it.
+
+**Example**
+```
+local languages = [
+    { name: 'scala', version: '3.1.3' },
+    { name: 'java', version: '19' }
+];
+
+xtr.objects.fromArray(languages, function(lang) lang.name, function(lang) lang.version)
+```
+**Result**
+```
+{
+    scala: '3.1.3',
+    java: '19'
+}
+```
 
 <br/>
 ## fullEqJoin
 ### fullEqJoin
-`fullEqJoin(arrL: Array[Object[A]], arrR: Array[Object[B]], identity: Func[(Object[A]) => String|Number|Boolean], identityR: Func[(Object[B]) => String|Number|Boolean) => Object[C]]): Array[Object[C]]`
+`fullEqJoin(arrL: Array[Object[A]], arrR: Array[Object[B]], funcIdL: Func[(Object[A]) => String|Number|Boolean|Null], funcIdR: Func[(Object[B]) => String|Number|Boolean|Null]): Array[Object[C]]`
 
-Returns a new `Array` with all the objects that exist in `arrL` or in `arrR`, joining those that exist in both with a shallow merge, and using the given `identity` functions to compute equality.
+Returns a new `Array` with all the objects that exist in `arrL` or in `arrR`, joining those that exist in both with a shallow merge, and using the given `funcIdL` and `funcIdR` identity functions to compute equality. On key collision the merged entry keeps the `arrL` object's value.
 
 **Example**
 ```
@@ -148,9 +182,9 @@ xtr.objects.fullEqJoin(customers, orders,
 
 <br/>
 ### fullEqJoin func(left, right) => joined
-`fullEqJoin(arrL: Array[Object[A]], arrR: Array[Object[B]], identity: Func[(Object[A]) => String|Number|Boolean], identityR: Func[(Object[B]) => String|Number|Boolean)score], join: Func[(Object[A], Object[B]) => Object[C]]): Array[Object[C]]`
+`fullEqJoin(arrL: Array[Object[A]], arrR: Array[Object[B]], funcIdL: Func[(Object[A]) => String|Number|Boolean|Null], funcIdR: Func[(Object[B]) => String|Number|Boolean|Null], funcJoin: Func[(Object[A], Object[B]) => Object[C]]): Array[Object[C]]`
 
-Returns a new `Array` with all the objects that exist in `arrL` or in `arrR`, joining those that exist in both with the given `join` function, and using the given `identity` functions to compute equality.
+Returns a new `Array` with all the objects that exist in `arrL` or in `arrR`, joining those that exist in both with the given `funcJoin` function, and using the given `funcIdL` and `funcIdR` identity functions to compute equality.
 
 **Example**
 ```
@@ -185,9 +219,9 @@ xtr.objects.fullEqJoin(customers, orders,
 <br/>
 ## innerEqJoin
 ### innerEqJoin
-`innerEqJoin(arrL: Array[Object[A]], arrR: Array[Object[B]], identity: Func[(Object[A]) => String|Number|Boolean], identityR: Func[(Object[B]) => String|Number|Boolean)]): Array[Object[C]]`
+`innerEqJoin(arrL: Array[Object[A]], arrR: Array[Object[B]], funcIdL: Func[(Object[A]) => String|Number|Boolean|Null], funcIdR: Func[(Object[B]) => String|Number|Boolean|Null]): Array[Object[C]]`
 
-Returns a new `Array` with all the objects that exist in both `arrL` _and_ `arrR`, using the given `identity` functions to compute equality, and joined using a shallow merge.
+Returns a new `Array` with all the objects that exist in both `arrL` _and_ `arrR`, using the given `funcIdL` and `funcIdR` identity functions to compute equality, and joined using a shallow merge. On key collision the merged entry keeps the `arrL` object's value.
 
 **Example**
 ```
@@ -221,9 +255,9 @@ xtr.objects.innerEqJoin(customers, orders,
 
 <br/>
 ### innerEqJoin func(left, right) => joined
-`innerEqJoin(arrL: Array[Object[A]], arrR: Array[Object[B]], identity: Func[(Object[A]) => String|Number|Boolean], identityR: Func[(Object[B]) => String|Number|Boolean), join: Func[(Object[A], Object[B]) => Object[C]]): Array[Object[C]]`
+`innerEqJoin(arrL: Array[Object[A]], arrR: Array[Object[B]], funcIdL: Func[(Object[A]) => String|Number|Boolean|Null], funcIdR: Func[(Object[B]) => String|Number|Boolean|Null], funcJoin: Func[(Object[A], Object[B]) => Object[C]]): Array[Object[C]]`
 
-Returns a new `Array` with all the objects that exist in both `arrL` _and_ `arrR`, using the given `identity` functions to compute equality, and joined using the given `join` function.
+Returns a new `Array` with all the objects that exist in both `arrL` _and_ `arrR`, using the given `funcIdL` and `funcIdR` identity functions to compute equality, and joined using the given `funcJoin` function.
 
 **Example**
 ```
@@ -255,10 +289,10 @@ xtr.objects.innerEqJoin(customers, orders,
 
 <br/>
 ## leftEqJoin
-### leftEqJoin func(left, right) => joined
-`leftEqJoin(arrL: Array[Object[A]], arrR: Array[Object[B]], identity: Func[(Object[A]) => String|Number|Boolean], identityR: Func[(Object[B]) => String|Number|Boolean)]): Array[Object[C]]`
+### leftEqJoin
+`leftEqJoin(arrL: Array[Object[A]], arrR: Array[Object[B]], funcIdL: Func[(Object[A]) => String|Number|Boolean|Null], funcIdR: Func[(Object[B]) => String|Number|Boolean|Null]): Array[Object[C]]`
 
-Returns a new `Array` with all the objects that exist in `arrL`, joined using a shallow merge with those that also exist in `arrR`, using the given `identity` functions to compute equality.
+Returns a new `Array` with all the objects that exist in `arrL`, joined using a shallow merge with those that also exist in `arrR`, using the given `funcIdL` and `funcIdR` identity functions to compute equality. On key collision the merged entry keeps the `arrL` object's value.
 
 **Example**
 ```
@@ -293,9 +327,9 @@ xtr.objects.leftEqJoin(customers, orders,
 
 <br/>
 ### leftEqJoin func(left, right) => joined
-`leftEqJoin(arrL: Array[Object[A]], arrR: Array[Object[B]], identity: Func[(Object[A]) => String|Number|Boolean], identityR: Func[(Object[B]) => String|Number|Boolean), join: Func[(Object[A], Object[B]) => Object[C]]): Array[Object[C]]`
+`leftEqJoin(arrL: Array[Object[A]], arrR: Array[Object[B]], funcIdL: Func[(Object[A]) => String|Number|Boolean|Null], funcIdR: Func[(Object[B]) => String|Number|Boolean|Null], funcJoin: Func[(Object[A], Object[B]) => Object[C]]): Array[Object[C]]`
 
-Returns a new `Array` with all the objects that exist in `arrL`, joined using the given `join` function with those that also exist in `arrR`, using the given `identity` functions to compute equality.
+Returns a new `Array` with all the objects that exist in `arrL`, joined using the given `funcJoin` function with those that also exist in `arrR`, using the given `funcIdL` and `funcIdR` identity functions to compute equality.
 
 **Example**
 ```

--- a/docs/xtr/objects.md
+++ b/docs/xtr/objects.md
@@ -146,7 +146,7 @@ xtr.objects.fromArray(languages, function(lang) lang.name, function(lang) lang.v
 ### fullEqJoin
 `fullEqJoin(arrL: Array[Object[A]], arrR: Array[Object[B]], funcIdL: Func[(Object[A]) => String|Number|Boolean|Null], funcIdR: Func[(Object[B]) => String|Number|Boolean|Null]): Array[Object[C]]`
 
-Returns a new `Array` with all the objects that exist in `arrL` or in `arrR`, joining those that exist in both with a shallow merge, and using the given `funcIdL` and `funcIdR` identity functions to compute equality. On key collision the merged entry keeps the `arrL` object's value.
+Returns a new `Array` with all the objects that exist in `arrL` or in `arrR`, joining those that exist in both with a shallow merge, and using the given `funcIdL` and `funcIdR` identity functions to compute equality. On key collision the merged entry keeps the `arrL` object's value. Rows follow `arrL`'s order, each expanded to its `arrR` matches in their order, with unmatched `arrR` objects appended last in their order.
 
 **Example**
 ```
@@ -184,7 +184,7 @@ xtr.objects.fullEqJoin(customers, orders,
 ### fullEqJoin func(left, right) => joined
 `fullEqJoin(arrL: Array[Object[A]], arrR: Array[Object[B]], funcIdL: Func[(Object[A]) => String|Number|Boolean|Null], funcIdR: Func[(Object[B]) => String|Number|Boolean|Null], funcJoin: Func[(Object[A], Object[B]) => Object[C]]): Array[Object[C]]`
 
-Returns a new `Array` with all the objects that exist in `arrL` or in `arrR`, joining those that exist in both with the given `funcJoin` function, and using the given `funcIdL` and `funcIdR` identity functions to compute equality.
+Returns a new `Array` with all the objects that exist in `arrL` or in `arrR`, joining those that exist in both with the given `funcJoin` function, and using the given `funcIdL` and `funcIdR` identity functions to compute equality. Rows follow `arrL`'s order, each expanded to its `arrR` matches in their order, with unmatched `arrR` objects appended last in their order.
 
 **Example**
 ```
@@ -221,7 +221,7 @@ xtr.objects.fullEqJoin(customers, orders,
 ### innerEqJoin
 `innerEqJoin(arrL: Array[Object[A]], arrR: Array[Object[B]], funcIdL: Func[(Object[A]) => String|Number|Boolean|Null], funcIdR: Func[(Object[B]) => String|Number|Boolean|Null]): Array[Object[C]]`
 
-Returns a new `Array` with all the objects that exist in both `arrL` _and_ `arrR`, using the given `funcIdL` and `funcIdR` identity functions to compute equality, and joined using a shallow merge. On key collision the merged entry keeps the `arrL` object's value.
+Returns a new `Array` with all the objects that exist in both `arrL` _and_ `arrR`, using the given `funcIdL` and `funcIdR` identity functions to compute equality, and joined using a shallow merge. On key collision the merged entry keeps the `arrL` object's value. Rows follow `arrL`'s order, each expanded to its `arrR` matches in their order.
 
 **Example**
 ```
@@ -257,7 +257,7 @@ xtr.objects.innerEqJoin(customers, orders,
 ### innerEqJoin func(left, right) => joined
 `innerEqJoin(arrL: Array[Object[A]], arrR: Array[Object[B]], funcIdL: Func[(Object[A]) => String|Number|Boolean|Null], funcIdR: Func[(Object[B]) => String|Number|Boolean|Null], funcJoin: Func[(Object[A], Object[B]) => Object[C]]): Array[Object[C]]`
 
-Returns a new `Array` with all the objects that exist in both `arrL` _and_ `arrR`, using the given `funcIdL` and `funcIdR` identity functions to compute equality, and joined using the given `funcJoin` function.
+Returns a new `Array` with all the objects that exist in both `arrL` _and_ `arrR`, using the given `funcIdL` and `funcIdR` identity functions to compute equality, and joined using the given `funcJoin` function. Rows follow `arrL`'s order, each expanded to its `arrR` matches in their order.
 
 **Example**
 ```
@@ -292,7 +292,7 @@ xtr.objects.innerEqJoin(customers, orders,
 ### leftEqJoin
 `leftEqJoin(arrL: Array[Object[A]], arrR: Array[Object[B]], funcIdL: Func[(Object[A]) => String|Number|Boolean|Null], funcIdR: Func[(Object[B]) => String|Number|Boolean|Null]): Array[Object[C]]`
 
-Returns a new `Array` with all the objects that exist in `arrL`, joined using a shallow merge with those that also exist in `arrR`, using the given `funcIdL` and `funcIdR` identity functions to compute equality. On key collision the merged entry keeps the `arrL` object's value.
+Returns a new `Array` with all the objects that exist in `arrL`, joined using a shallow merge with those that also exist in `arrR`, using the given `funcIdL` and `funcIdR` identity functions to compute equality. On key collision the merged entry keeps the `arrL` object's value. Rows follow `arrL`'s order, each expanded to its `arrR` matches in their order.
 
 **Example**
 ```
@@ -329,7 +329,7 @@ xtr.objects.leftEqJoin(customers, orders,
 ### leftEqJoin func(left, right) => joined
 `leftEqJoin(arrL: Array[Object[A]], arrR: Array[Object[B]], funcIdL: Func[(Object[A]) => String|Number|Boolean|Null], funcIdR: Func[(Object[B]) => String|Number|Boolean|Null], funcJoin: Func[(Object[A], Object[B]) => Object[C]]): Array[Object[C]]`
 
-Returns a new `Array` with all the objects that exist in `arrL`, joined using the given `funcJoin` function with those that also exist in `arrR`, using the given `funcIdL` and `funcIdR` identity functions to compute equality.
+Returns a new `Array` with all the objects that exist in `arrL`, joined using the given `funcJoin` function with those that also exist in `arrR`, using the given `funcIdL` and `funcIdR` identity functions to compute equality. Rows follow `arrL`'s order, each expanded to its `arrR` matches in their order.
 
 **Example**
 ```

--- a/docs/xtr/strings.md
+++ b/docs/xtr/strings.md
@@ -165,6 +165,38 @@ xtr.strings.leftPad('Hello', 10, ' ')
 ```
 
 <br/>
+## match
+`match(str: String, regex: String): Array[String|Null] | Null`
+
+Matches the entire `str` against the given [Java regular expression](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/regex/Pattern.html) `regex`.
+
+Returns an `Array` with the entire match followed by the value of each capture group, where groups that did not participate in the match are `null`. Returns `null` if `str` does not match, which composes with the `??` operator.
+
+**Example**
+```
+xtr.strings.match('user@example.com', '(\\w+)@([\\w.]+)')
+```
+**Result**
+```
+['user@example.com', 'user', 'example.com']
+```
+
+<br/>
+## matches
+`matches(str: String, regex: String): Boolean`
+
+Reports whether the entire `str` matches the given [Java regular expression](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/regex/Pattern.html) `regex`.
+
+**Example**
+```
+xtr.strings.matches('say user@example.com twice', '\\w+@[\\w.]+')
+```
+**Result**
+```
+false
+```
+
+<br/>
 ## numOrdinalOf
 `numOrdinalOf(num: Number): String`
 
@@ -241,6 +273,23 @@ xtr.strings.rightPad('Hello', 10, ' ')
 ```
 
 [//]: # (todo: document algo)
+<br/>
+## scan
+`scan(str: String, regex: String): Array[Array[String|Null]]`
+
+Finds every match of the given [Java regular expression](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/regex/Pattern.html) `regex` within `str`.
+
+Returns an `Array` with one element per match, each an `Array` of the entire match followed by the value of each capture group, where groups that did not participate in the match are `null`. Returns an empty `Array` if there are no matches.
+
+**Example**
+```
+xtr.strings.scan('write to a1@b1.com or a2@b2.com', '(\\w+)@([\\w.]+)')
+```
+**Result**
+```
+[['a1@b1.com', 'a1', 'b1.com'], ['a2@b2.com', 'a2', 'b2.com']]
+```
+
 <br/>
 ## singularize
 `singularize(word: String): String`

--- a/docs/xtr/strings.md
+++ b/docs/xtr/strings.md
@@ -1,9 +1,9 @@
 # xtr.strings
 
 ## appendIfMissing
-`appendIfMissing(str: String, suffix: String): String`
+`appendIfMissing(str1: String, str2: String): String`
 
-Returns `str`, appended with `suffix` if it does not already end with `suffix`.
+Returns `str1`, appended with `str2` if it does not already end with `str2`.
 
 **Example**
 ```
@@ -31,9 +31,9 @@ xtr.strings.capitalize('hello world')
 
 <br/>
 ## charCode
-`charCode(char: String): String`
+`charCode(str: String): Number`
 
-Returns the character-code for the given `char`.
+Returns the character-code for the given `str`, a single character.
 
 **Example**
 ```
@@ -46,9 +46,9 @@ xtr.strings.charCode('*')
 
 <br/>
 ## charCodeAt
-`charCodeAt(str: String, index: Number): String`
+`charCodeAt(str: String, num: Number): Number`
 
-Returns the character-code for the character at the given `index` in `str`.
+Returns the character-code for the character at the given `num` index in `str`.
 
 **Example**
 ```
@@ -61,7 +61,7 @@ xtr.strings.charCodeAt('_*_', 1)
 
 <br/>
 ## ofCharCode
-`ofCharCode(code: Number): String`
+`ofCharCode(num: Number): String`
 
 Returns the character for the given character-code.
 
@@ -76,7 +76,7 @@ xtr.strings.ofCharCode(42)
 
 <br/>
 ## isAlpha
-`isAlpha(str: String): String`
+`isAlpha(str: String|Number|Boolean): Boolean`
 
 Returns `true` if the given `str` contains only alphabetic characters, otherwise `false`.
 
@@ -91,7 +91,7 @@ true
 
 <br/>
 ## isAlphanumeric
-`isAlphanumeric(str: String): String`
+`isAlphanumeric(str: String|Number|Boolean): Boolean`
 
 Returns `true` if the given `str` contains only alphanumeric characters, otherwise `false`.
 
@@ -106,7 +106,7 @@ true
 
 <br/>
 ## isLowerCase
-`isLowerCase(str: String): String`
+`isLowerCase(str: String): Boolean`
 
 Returns `true` if the alphabetic characters in the given `str` are all lowercase, otherwise `false`.
 
@@ -121,7 +121,7 @@ true
 
 <br/>
 ## isNumeric
-`isNumeric(str: String): String`
+`isNumeric(str: String|Number|Boolean): Boolean`
 
 Returns `true` if the given `str` contains only numeric characters.
 
@@ -136,9 +136,9 @@ true
 
 <br/>
 ## isUpperCase
-`isUpperCase(str: String): String`
+`isUpperCase(str: String): Boolean`
 
-Returns `true` if the alphabetic characters in the given `str` are all uppercse, otherwise `false`.
+Returns `true` if the alphabetic characters in the given `str` are all uppercase, otherwise `false`.
 
 **Example**
 ```
@@ -151,9 +151,9 @@ true
 
 <br/>
 ## leftPad
-`leftPad(str: String, size: Number, char: String): String`
+`leftPad(str: String|Number, offset: Number, pad: String): String`
 
-Returns `str` prepended with enough repetitions of `char` required to meet the given `size`, otherwise returns `str` if its size is already equal or longer than `size`. Only the first character of `char` is used, and it must not be empty. `str` itself is never altered.
+Returns `str` prepended with enough repetitions of `pad` required to meet the given `offset` size; a `str` already that long -- including any negative or zero `offset` -- is returned unchanged. Only the first character of `pad` is used, and an empty `pad` is an error. A `Number` value for `str` is stringified the same way as `xtr.toString`.
 
 **Example**
 ```
@@ -198,9 +198,9 @@ false
 
 <br/>
 ## numOrdinalOf
-`numOrdinalOf(num: Number): String`
+`numOrdinalOf(num: Number|String): String`
 
-Returns the numeric ordinal name for the given `num`.
+Returns the numeric ordinal name for the given `num`. A `String` is accepted if its contents are numeric; anything else is an error.
 
 **Example**
 ```
@@ -214,9 +214,9 @@ xtr.strings.numOrdinalOf(1)
 [//]: # ( todo: document algo)
 <br/>
 ## pluralize
-`pluralize(word: String): String`
+`pluralize(value: String): String`
 
-Returns the plural of the given `word`.
+Returns the plural of the given `value`.
 
 **Example**
 ```
@@ -229,9 +229,9 @@ xtr.strings.pluralize('car')
 
 <br/>
 ## prependIfMissing
-`prependIfMissing(str: String, prefix: String): String`
+`prependIfMissing(str1: String, str2: String): String`
 
-Returns `str`, prepended with `prefix` if it does not already start with `prefix`.
+Returns `str1`, prepended with `str2` if it does not already start with `str2`.
 
 **Example**
 ```
@@ -244,9 +244,9 @@ xtr.strings.prependIfMissing('World', 'Hello ')
 
 <br/>
 ## repeat
-`repeat(str: String, n: Number): String`
+`repeat(str: String, num: Number): String`
 
-Returns `str` repeated `n` times.
+Returns `str` repeated `num` times.
 
 **Example**
 ```
@@ -259,9 +259,9 @@ xtr.strings.repeat('hey ', 2)
 
 <br/>
 ## rightPad
-`rightPad(str: String, size: Number, char: String): String`
+`rightPad(str: String|Number, offset: Number, pad: String): String`
 
-Returns `str` appended with enough repetitions of `char` required to meet the given `size`, otherwise returns `str` if its size is already equal or longer than `size`. Only the first character of `char` is used, and it must not be empty.
+Returns `str` appended with enough repetitions of `pad` required to meet the given `offset` size; a `str` already that long -- including any negative or zero `offset` -- is returned unchanged. Only the first character of `pad` is used, and an empty `pad` is an error. A `Number` value for `str` is stringified the same way as `xtr.toString`.
 
 **Example**
 ```
@@ -292,9 +292,9 @@ xtr.strings.scan('write to a1@b1.com or a2@b2.com', '(\\w+)@([\\w.]+)')
 
 <br/>
 ## singularize
-`singularize(word: String): String`
+`singularize(value: String): String`
 
-Returns the singular of the given `word`.
+Returns the singular of the given `value`.
 
 **Example**
 ```
@@ -307,9 +307,9 @@ xtr.strings.singularize('cars')
 
 <br/>
 ## substringAfter
-`substringAfter(str1: String, str2: String): String`
+`substringAfter(value: String, sep: String): String`
 
-Returns the contents of `str1` after the first occurrence of `str2`, otherwise returns `str1` if it does not contain `str2`.
+Returns the contents of `value` after the first occurrence of `sep`, or an empty `String` if `value` does not contain `sep`.
 
 **Example**
 ```
@@ -322,9 +322,9 @@ xtr.strings.substringAfter('!XHelloXWorldXAfter', 'X')
 
 <br/>
 ## substringAfterLast
-`substringAfterLast(str1: String, str2: String): String`
+`substringAfterLast(value: String, sep: String): String`
 
-Returns the contents of `str1` after the last occurrence of `str2`, otherwise returns `str1` if it does not contain `str2`.
+Returns the contents of `value` after the last occurrence of `sep`, or an empty `String` if `value` does not contain `sep`.
 
 **Example**
 ```
@@ -337,9 +337,9 @@ xtr.strings.substringAfterLast('!XHelloXWorldXAfter', 'X')
 
 <br/>
 ## substringBefore
-`substringBefore(str1: String, str2: String): String`
+`substringBefore(value: String, sep: String): String`
 
-Returns the contents of `str1` before the first occurrence of `str2`, otherwise returns `str1` if it does not contain `str2`.
+Returns the contents of `value` before the first occurrence of `sep`, or an empty `String` if `value` does not contain `sep`.
 
 **Example**
 ```
@@ -352,9 +352,9 @@ xtr.strings.substringBefore('!XHelloXWorldXAfter', 'X')
 
 <br/>
 ## substringBeforeLast
-`substringBeforeLast(str1: String, str2: String): String`
+`substringBeforeLast(value: String, sep: String): String`
 
-Returns the contents of `str1` before the last occurrence of `str2`, otherwise returns `str1` if it does not contain `str2`.
+Returns the contents of `value` before the last occurrence of `sep`, or an empty `String` if `value` does not contain `sep`.
 
 **Example**
 ```
@@ -412,9 +412,9 @@ xtr.strings.toSnakeCase('Hello WorldX')
 
 <br/>
 ## unwrap
-`unwrap(str: String, wrap: String): String`
+`unwrap(value: String, wrapper: String): String`
 
-Returns `str` without the given `wrap` as prefix and suffix, if found.
+Returns `value` without the given `wrapper` as prefix and suffix, when both are present. When only one is present it is moved to the other side: a prefix-only match strips the prefix and appends the `wrapper`, a suffix-only match strips the suffix and prepends it.
 
 **Example**
 ```
@@ -427,7 +427,7 @@ xtr.strings.unwrap('_Hello, world!_', '_')
 
 <br/>
 ## wrap
-`wrap(str: String, wrap: String): String`
+`wrap(value: String, wrapper: String): String`
 
 Returns `str`, prepended and appended with `wrap`.
 
@@ -442,7 +442,7 @@ xtr.strings.wrap('_Hello, world!', '_')
 
 <br/>
 ## wrapIfMissing
-`wrapIfMissing(str: String, wrap: String): String`
+`wrapIfMissing(value: String, wrapper: String): String`
 
 Returns `str`, prepended and appended with `wrap`, if not found.
 

--- a/xtrasonnet/src/main/java/io/github/jam01/xtrasonnet/document/MediaTypeUtils.java
+++ b/xtrasonnet/src/main/java/io/github/jam01/xtrasonnet/document/MediaTypeUtils.java
@@ -33,9 +33,11 @@ import org.jspecify.annotations.Nullable;
  * - Removed generateMultipartBoundary and related methods
  * - Refactored parameter parsing to method
  * - Only parse params if ; in media type
+ * - Moved the nested ConcurrentLruCache class to its own file, io.github.jam01.xtrasonnet.util.ConcurrentLruCache
  */
 
 import io.github.jam01.xtrasonnet.Utils;
+import io.github.jam01.xtrasonnet.util.ConcurrentLruCache;
 
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.ArrayList;
@@ -47,11 +49,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -286,87 +283,6 @@ public abstract class MediaTypeUtils {
         Objects.requireNonNull(mimeTypes, "'mimeTypes' must not be null");
         if (mimeTypes.size() > 1) {
             mimeTypes.sort(SPECIFICITY_COMPARATOR);
-        }
-    }
-
-    /**
-     * Simple Least Recently Used cache, bounded by the maximum size given
-     * to the class constructor.
-     * <p>This implementation is backed by a {@code ConcurrentHashMap} for storing
-     * the cached values and a {@code ConcurrentLinkedQueue} for ordering the keys
-     * and choosing the least recently used key when the cache is at full capacity.
-     *
-     * @param <K> the type of the key used for caching
-     * @param <V> the type of the cached values
-     */
-    private static class ConcurrentLruCache<K, V> {
-
-        private final int maxSize;
-
-        private final ConcurrentLinkedDeque<K> queue = new ConcurrentLinkedDeque<>();
-
-        private final ConcurrentHashMap<K, V> cache = new ConcurrentHashMap<>();
-
-        private final ReadWriteLock lock;
-
-        private final Function<K, V> generator;
-
-        private volatile int size;
-
-        public ConcurrentLruCache(int maxSize, Function<K, V> generator) {
-            if (maxSize <= 0) {
-                throw new IllegalArgumentException("LRU max size should be positive");
-            }
-
-            Objects.requireNonNull(generator, "Generator function should not be null");
-            this.maxSize = maxSize;
-            this.generator = generator;
-            this.lock = new ReentrantReadWriteLock();
-        }
-
-        public V get(K key) {
-            V cached = this.cache.get(key);
-            if (cached != null) {
-                if (this.size < this.maxSize) {
-                    return cached;
-                }
-                this.lock.readLock().lock();
-                try {
-                    if (this.queue.removeLastOccurrence(key)) {
-                        this.queue.offer(key);
-                    }
-                    return cached;
-                } finally {
-                    this.lock.readLock().unlock();
-                }
-            }
-            this.lock.writeLock().lock();
-            try {
-                // Retrying in case of concurrent reads on the same key
-                cached = this.cache.get(key);
-                if (cached != null) {
-                    if (this.queue.removeLastOccurrence(key)) {
-                        this.queue.offer(key);
-                    }
-                    return cached;
-                }
-                // Generate value first, to prevent size inconsistency
-                V value = this.generator.apply(key);
-                int cacheSize = this.size;
-                if (cacheSize == this.maxSize) {
-                    K leastUsed = this.queue.poll();
-                    if (leastUsed != null) {
-                        this.cache.remove(leastUsed);
-                        cacheSize--;
-                    }
-                }
-                this.queue.offer(key);
-                this.cache.put(key, value);
-                this.size = cacheSize + 1;
-                return value;
-            } finally {
-                this.lock.writeLock().unlock();
-            }
         }
     }
 }

--- a/xtrasonnet/src/main/java/io/github/jam01/xtrasonnet/util/ConcurrentLruCache.java
+++ b/xtrasonnet/src/main/java/io/github/jam01/xtrasonnet/util/ConcurrentLruCache.java
@@ -1,0 +1,117 @@
+package io.github.jam01.xtrasonnet.util;
+
+/*-
+ * Copyright 2022-2026 Jose Montoya.
+ *
+ * Licensed under the Elastic License 2.0; you may not use this file except in
+ * compliance with the Elastic License 2.0.
+ */
+
+/* spring-framework copyright/notice, per Apache-2.0 § 4.c */
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Changes made:
+ * - moved out of MediaTypeUtils into its own file, so other callers can reuse it
+ */
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
+
+/**
+ * Simple Least Recently Used cache, bounded by the maximum size given
+ * to the class constructor.
+ * <p>This implementation is backed by a {@code ConcurrentHashMap} for storing
+ * the cached values and a {@code ConcurrentLinkedQueue} for ordering the keys
+ * and choosing the least recently used key when the cache is at full capacity.
+ *
+ * @param <K> the type of the key used for caching
+ * @param <V> the type of the cached values
+ */
+public class ConcurrentLruCache<K, V> {
+
+    private final int maxSize;
+
+    private final ConcurrentLinkedDeque<K> queue = new ConcurrentLinkedDeque<>();
+
+    private final ConcurrentHashMap<K, V> cache = new ConcurrentHashMap<>();
+
+    private final ReadWriteLock lock;
+
+    private final Function<K, V> generator;
+
+    private volatile int size;
+
+    public ConcurrentLruCache(int maxSize, Function<K, V> generator) {
+        if (maxSize <= 0) {
+            throw new IllegalArgumentException("LRU max size should be positive");
+        }
+
+        Objects.requireNonNull(generator, "Generator function should not be null");
+        this.maxSize = maxSize;
+        this.generator = generator;
+        this.lock = new ReentrantReadWriteLock();
+    }
+
+    public V get(K key) {
+        V cached = this.cache.get(key);
+        if (cached != null) {
+            if (this.size < this.maxSize) {
+                return cached;
+            }
+            this.lock.readLock().lock();
+            try {
+                if (this.queue.removeLastOccurrence(key)) {
+                    this.queue.offer(key);
+                }
+                return cached;
+            } finally {
+                this.lock.readLock().unlock();
+            }
+        }
+        this.lock.writeLock().lock();
+        try {
+            // Retrying in case of concurrent reads on the same key
+            cached = this.cache.get(key);
+            if (cached != null) {
+                if (this.queue.removeLastOccurrence(key)) {
+                    this.queue.offer(key);
+                }
+                return cached;
+            }
+            // Generate value first, to prevent size inconsistency
+            V value = this.generator.apply(key);
+            int cacheSize = this.size;
+            if (cacheSize == this.maxSize) {
+                K leastUsed = this.queue.poll();
+                if (leastUsed != null) {
+                    this.cache.remove(leastUsed);
+                    cacheSize--;
+                }
+            }
+            this.queue.offer(key);
+            this.cache.put(key, value);
+            this.size = cacheSize + 1;
+            return value;
+        } finally {
+            this.lock.writeLock().unlock();
+        }
+    }
+}

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Arrays.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Arrays.scala
@@ -118,7 +118,7 @@ object Arrays extends AbstractFunctionModule {
             i = i + 1
           }
         } else {
-          Error.fail("Expected embedded function to have 1 parameters, received: " + args)
+          Error.fail("Expected embedded function to have 1 parameter, received: " + args)
         }
         Val.Arr(pos, out.toArray)
     },

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Arrays.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Arrays.scala
@@ -181,6 +181,16 @@ object Arrays extends AbstractFunctionModule {
         Val.Arr(pos, transpose(array.asLazyArray, pos))
     },
 
+    builtin("unzipAll", "array", "fill") {
+      (pos, _, array: Val.Arr, fill: Val) =>
+        Val.Arr(pos, transposeAll(array.asLazyArray, fill, pos))
+    },
+
+    builtin("zipAll", "array", "fill") {
+      (pos, _, array: Val.Arr, fill: Val) =>
+        Val.Arr(pos, transposeAll(array.asLazyArray, fill, pos))
+    },
+
     builtinWithDefaults("zip",
       "arr1" -> null,
       "arr2" -> null,
@@ -262,7 +272,7 @@ object Arrays extends AbstractFunctionModule {
    * Transposes the given arrays, truncating to the shortest of them.
    *
    * The documented contract for both zip and unzip is "equal size to the shortest array". Filling short
-   * arrays is what the (still unimplemented) zipAll/unzipAll are for.
+   * arrays is what zipAll/unzipAll are for.
    */
   private def transpose(arrays: Array[? <: Lazy], pos: Position): Array[Lazy] = {
     val inner = arrays.map(
@@ -280,6 +290,32 @@ object Arrays extends AbstractFunctionModule {
       var j = 0
       while (j < inner.length) {
         current(j) = inner(j)(i)
+        j = j + 1
+      }
+      out(i) = Val.Arr(pos, current)
+      i = i + 1
+    }
+
+    out
+  }
+
+  /** Transposes the given arrays, extending to the longest of them with the given fill value. */
+  private def transposeAll(arrays: Array[? <: Lazy], fill: Val, pos: Position): Array[Lazy] = {
+    val inner = arrays.map(
+      _.force match {
+        case arr: Val.Arr => arr.asLazyArray
+        case x => Error.fail("Expected Array of Arrays, got inner: " + x.prettyName)
+      })
+
+    val size = if (inner.isEmpty) 0 else inner.map(_.length).max
+    val out = new Array[Lazy](size)
+
+    var i = 0
+    while (i < size) {
+      val current = new Array[Lazy](inner.length)
+      var j = 0
+      while (j < inner.length) {
+        current(j) = if (i < inner(j).length) inner(j)(i) else fill
         j = j + 1
       }
       out(i) = Val.Arr(pos, current)

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Arrays.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Arrays.scala
@@ -280,21 +280,14 @@ object Arrays extends AbstractFunctionModule {
         case x => Error.fail("Expected Array of Arrays, got inner: " + x.prettyName)
       })
 
-    var size = 0
-    var j = 1
-    if (inner.nonEmpty) {
-      size = inner(0).length
-      while (j < inner.length) {
-        size = if (fill == null) math.min(size, inner(j).length) else math.max(size, inner(j).length)
-        j = j + 1
-      }
-    }
+    val lens = inner.map(_.length)
+    val size = if (inner.isEmpty) 0 else if (fill == null) lens.min else lens.max
     val out = new Array[Lazy](size)
 
     var i = 0
     while (i < size) {
       val current = new Array[Lazy](inner.length)
-      j = 0
+      var j = 0
       while (j < inner.length) {
         val row = inner(j)
         current(j) = if (i < row.length) row(i) else fill

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Arrays.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Arrays.scala
@@ -178,17 +178,17 @@ object Arrays extends AbstractFunctionModule {
 
     builtin("unzip", "array") {
       (pos, _, array: Val.Arr) =>
-        Val.Arr(pos, transpose(array.asLazyArray, pos))
+        Val.Arr(pos, transpose(array.asLazyArray, null, pos))
     },
 
     builtin("unzipAll", "array", "fill") {
       (pos, _, array: Val.Arr, fill: Val) =>
-        Val.Arr(pos, transposeAll(array.asLazyArray, fill, pos))
+        Val.Arr(pos, transpose(array.asLazyArray, fill, pos))
     },
 
     builtin("zipAll", "array", "fill") {
       (pos, _, array: Val.Arr, fill: Val) =>
-        Val.Arr(pos, transposeAll(array.asLazyArray, fill, pos))
+        Val.Arr(pos, transpose(array.asLazyArray, fill, pos))
     },
 
     builtinWithDefaults("zip",
@@ -203,7 +203,7 @@ object Arrays extends AbstractFunctionModule {
         case x => Error.fail("Expected Array, got: " + x.prettyName) // give param index?
       }
 
-      Val.Arr(pos, transpose(lazyArr, pos))
+      Val.Arr(pos, transpose(lazyArr, null, pos))
     },
 
     /*
@@ -269,53 +269,35 @@ object Arrays extends AbstractFunctionModule {
   )
 
   /**
-   * Transposes the given arrays, truncating to the shortest of them.
-   *
-   * The documented contract for both zip and unzip is "equal size to the shortest array". Filling short
-   * arrays is what zipAll/unzipAll are for.
+   * Transposes the given arrays: with a null fill it truncates to the shortest of them (the documented
+   * contract for zip and unzip), otherwise it extends to the longest, filling the missing elements
+   * (zipAll and unzipAll).
    */
-  private def transpose(arrays: Array[? <: Lazy], pos: Position): Array[Lazy] = {
+  private def transpose(arrays: Array[? <: Lazy], fill: Val, pos: Position): Array[Lazy] = {
     val inner = arrays.map(
       _.force match {
         case arr: Val.Arr => arr.asLazyArray
         case x => Error.fail("Expected Array of Arrays, got inner: " + x.prettyName)
       })
 
-    val size = if (inner.isEmpty) 0 else inner.map(_.length).min
-    val out = new Array[Lazy](size)
-
-    var i = 0
-    while (i < size) {
-      val current = new Array[Lazy](inner.length)
-      var j = 0
+    var size = 0
+    var j = 1
+    if (inner.nonEmpty) {
+      size = inner(0).length
       while (j < inner.length) {
-        current(j) = inner(j)(i)
+        size = if (fill == null) math.min(size, inner(j).length) else math.max(size, inner(j).length)
         j = j + 1
       }
-      out(i) = Val.Arr(pos, current)
-      i = i + 1
     }
-
-    out
-  }
-
-  /** Transposes the given arrays, extending to the longest of them with the given fill value. */
-  private def transposeAll(arrays: Array[? <: Lazy], fill: Val, pos: Position): Array[Lazy] = {
-    val inner = arrays.map(
-      _.force match {
-        case arr: Val.Arr => arr.asLazyArray
-        case x => Error.fail("Expected Array of Arrays, got inner: " + x.prettyName)
-      })
-
-    val size = if (inner.isEmpty) 0 else inner.map(_.length).max
     val out = new Array[Lazy](size)
 
     var i = 0
     while (i < size) {
       val current = new Array[Lazy](inner.length)
-      var j = 0
+      j = 0
       while (j < inner.length) {
-        current(j) = if (i < inner(j).length) inner(j)(i) else fill
+        val row = inner(j)
+        current(j) = if (i < row.length) row(i) else fill
         j = j + 1
       }
       out(i) = Val.Arr(pos, current)

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Arrays.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Arrays.scala
@@ -181,14 +181,16 @@ object Arrays extends AbstractFunctionModule {
         Val.Arr(pos, transpose(array.asLazyArray, null, pos))
     },
 
+    // unzipAll and zipAll are the same operation under different names: transposing rows/columns
+    // while padding ragged rows with fill instead of dropping them.
     builtin("unzipAll", "array", "fill") {
       (pos, _, array: Val.Arr, fill: Val) =>
-        Val.Arr(pos, transpose(array.asLazyArray, fill, pos))
+        transposeFilled(pos, array, fill)
     },
 
     builtin("zipAll", "array", "fill") {
       (pos, _, array: Val.Arr, fill: Val) =>
-        Val.Arr(pos, transpose(array.asLazyArray, fill, pos))
+        transposeFilled(pos, array, fill)
     },
 
     builtinWithDefaults("zip",
@@ -267,6 +269,9 @@ object Arrays extends AbstractFunctionModule {
      * datasonnet-mapper: end
      */
   )
+
+  private def transposeFilled(pos: Position, array: Val.Arr, fill: Val): Val.Arr =
+    Val.Arr(pos, transpose(array.asLazyArray, fill, pos))
 
   /**
    * Transposes the given arrays: with a null fill it truncates to the shortest of them (the documented

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Datetime.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Datetime.scala
@@ -34,16 +34,31 @@ package io.github.jam01.xtrasonnet.modules
 
 import io.github.jam01.xtrasonnet.modules.{Duration => Durations}
 import sjsonnet.functions.AbstractFunctionModule
-import sjsonnet.{Error, Val}
+import sjsonnet.{Error, Position, Val}
 
 import java.time.format.DateTimeFormatter
 import java.time.{Duration, Instant, OffsetDateTime, Period, ZoneOffset}
 import scala.collection.mutable
 
 object Datetime extends AbstractFunctionModule {
-  // every key emitted by toParts, so that of(toParts(x)) keeps working; dayOfWeek is derived and ignored
-  private val datetimePartNames =
+  // the parts toParts emits, and the only keys of accepts; toParts emits exactly these (see below),
+  // so a part can't be added to one without the other. dayOfWeek is derived and of ignores it
+  private val partNames =
     Array("year", "month", "day", "dayOfWeek", "hour", "minute", "second", "nanosecond", "offset")
+
+  private def partValue(pos: Position, date: OffsetDateTime, name: String): Val = name match {
+    case "year" => Val.Num(pos, date.getYear)
+    case "month" => Val.Num(pos, date.getMonthValue)
+    // day is day-of-month: datetime.of reads this key back as the day-of-month, so emitting
+    // day-of-week here made of(toParts(x)) produce a different date than x
+    case "day" => Val.Num(pos, date.getDayOfMonth)
+    case "dayOfWeek" => Val.Num(pos, date.getDayOfWeek.getValue)
+    case "hour" => Val.Num(pos, date.getHour)
+    case "minute" => Val.Num(pos, date.getMinute)
+    case "second" => Val.Num(pos, date.getSecond)
+    case "nanosecond" => Val.Num(pos, date.getNano)
+    case "offset" => Val.Str(pos, date.getOffset.getId)
+  }
 
   override def name: String = "datetime"
 
@@ -165,17 +180,7 @@ object Datetime extends AbstractFunctionModule {
       (pos, _, datetime: String) =>
         val date = OffsetDateTime.parse(datetime)
         val out = new java.util.LinkedHashMap[String, Val.Obj.Member]
-        out.put("year", memberOf(Val.Num(pos, date.getYear)))
-        out.put("month", memberOf(Val.Num(pos, date.getMonthValue)))
-        // day is day-of-month: datetime.of reads this key back as the day-of-month, so emitting
-        // day-of-week here made of(toParts(x)) produce a different date than x
-        out.put("day", memberOf(Val.Num(pos, date.getDayOfMonth)))
-        out.put("dayOfWeek", memberOf(Val.Num(pos, date.getDayOfWeek.getValue)))
-        out.put("hour", memberOf(Val.Num(pos, date.getHour)))
-        out.put("minute", memberOf(Val.Num(pos, date.getMinute)))
-        out.put("second", memberOf(Val.Num(pos, date.getSecond)))
-        out.put("nanosecond", memberOf(Val.Num(pos, date.getNano)))
-        out.put("offset", memberOf(Val.Str(pos, date.getOffset.getId)))
+        partNames.foreach(name => out.put(name, memberOf(partValue(pos, date, name))))
 
         new Val.Obj(pos, out, false, null, null)
     },
@@ -292,7 +297,7 @@ object Datetime extends AbstractFunctionModule {
       (pos, ev, obj: Val.Obj) =>
         val out = mutable.Map[String, Val]()
         obj.visibleKeyNames.foreach { key =>
-          if (!datetimePartNames.contains(key)) Error.fail("Unexpected datetime part: " + key)
+          if (!partNames.contains(key)) Error.fail("Unexpected datetime part: " + key)
           out.addOne(key, obj.value(key, pos)(ev))
         }
         OffsetDateTime.of(

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Datetime.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Datetime.scala
@@ -32,6 +32,7 @@ package io.github.jam01.xtrasonnet.modules
  *      Functions: datetime.parse
  */
 
+import io.github.jam01.xtrasonnet.modules.{Duration => Durations}
 import sjsonnet.functions.AbstractFunctionModule
 import sjsonnet.{Error, Val}
 
@@ -62,33 +63,13 @@ object Datetime extends AbstractFunctionModule {
     },
 
     builtin("plus", "datetime", "duration") { (_, _, date: String, duration: String) =>
-      var datetime = OffsetDateTime.parse(date)
-      val timeIdx = duration.indexOf('T')
-
-      if (timeIdx != -1) {
-        datetime = datetime
-          .plus(Duration.parse("P" + duration.substring(timeIdx)))
-          .plus(Period.parse(duration.substring(0, timeIdx)))
-      } else {
-        datetime = datetime.plus(Period.parse(duration))
-      }
-
-      datetime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+      val (period, dduration) = Durations.parseParts(duration)
+      OffsetDateTime.parse(date).plus(period).plus(dduration).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
     },
 
     builtin("minus", "datetime", "duration") { (_, _, date: String, duration: String) =>
-      var datetime = OffsetDateTime.parse(date)
-      val timeIdx = duration.indexOf('T')
-
-      if (timeIdx != -1) {
-        datetime = datetime
-          .minus(Duration.parse("P" + duration.substring(timeIdx)))
-          .minus(Period.parse(duration.substring(0, timeIdx)))
-      } else {
-        datetime = datetime.minus(Period.parse(duration))
-      }
-
-      datetime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+      val (period, dduration) = Durations.parseParts(duration)
+      OffsetDateTime.parse(date).minus(period).minus(dduration).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
     },
 
     builtin("inOffset", "datetime", "offset") {

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Datetime.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Datetime.scala
@@ -40,6 +40,10 @@ import java.time.{Duration, Instant, OffsetDateTime, Period, ZoneOffset}
 import scala.collection.mutable
 
 object Datetime extends AbstractFunctionModule {
+  // every key emitted by toParts, so that of(toParts(x)) keeps working; dayOfWeek is derived and ignored
+  private val datetimePartNames =
+    Array("year", "month", "day", "dayOfWeek", "hour", "minute", "second", "nanosecond", "offset")
+
   override def name: String = "datetime"
 
   val functions: Seq[(String, Val.Func)] = Seq(
@@ -304,9 +308,11 @@ object Datetime extends AbstractFunctionModule {
      */
     builtin("of", "obj") {
       (pos, ev, obj: Val.Obj) =>
-        //year, month, dayOfMonth, hour, minute, second, nanoSecond, zoneId
         val out = mutable.Map[String, Val]()
-        obj.visibleKeyNames.foreach(key => out.addOne(key, obj.value(key, pos)(ev)))
+        obj.visibleKeyNames.foreach { key =>
+          if (!datetimePartNames.contains(key)) Error.fail("Unexpected datetime part: " + key)
+          out.addOne(key, obj.value(key, pos)(ev))
+        }
         OffsetDateTime.of(
           out.getOrElse("year", Val.Num(pos, 0)).asInt,
           out.getOrElse("month", Val.Num(pos, 1)).asInt,

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Datetime.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Datetime.scala
@@ -305,6 +305,7 @@ object Datetime extends AbstractFunctionModule {
      * - 807cd78abf40551644067455338e5b2a683e86bd: upgraded sjsonnet
      * - fc930f88524269cb6ddfa26b24f8c34df5502756: refactor datetime and period modules
      * - a192423d89a9bdb898a3d3314db306a4a9d10773: rename epoch format to unix
+     * - ac43b61a66a17dd9107f1aa27a4965c245d61caa: reject unknown part names
      */
     builtin("of", "obj") {
       (pos, ev, obj: Val.Obj) =>

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Duration.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Duration.scala
@@ -67,8 +67,9 @@ object Duration extends AbstractFunctionModule {
         // ISO-8601 allows a single leading sign for the whole duration; parseParts produces
         // (and accepts) that form, and toParts puts every part on the same side of zero for a
         // negative duration, so prefer it here too rather than java.time's per-component signs
-        val negative = Seq(years, months, days, hours, minutes, nanos).forall(_ <= 0) &&
-          Seq(years, months, days, hours, minutes, nanos).exists(_ < 0)
+        val (allNonPositive, anyNegative) = Seq(years, months, days, hours, minutes, nanos)
+          .foldLeft((true, false)) { case ((allLE, anyLT), v) => (allLE && v <= 0, anyLT || v < 0) }
+        val negative = allNonPositive && anyNegative
 
         try {
           var period = Period.ZERO.plusYears(years).plusMonths(months).plusDays(days)

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Duration.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Duration.scala
@@ -57,19 +57,33 @@ object Duration extends AbstractFunctionModule {
           out.addOne(key, obj.value(key, pos)(ev))
         }
 
-        try {
-          val period = Period.ZERO
-            .plusYears(wholePart(out, "years"))
-            .plusMonths(wholePart(out, "months"))
-            .plusDays(wholePart(out, "days"))
-          val dduration = java.time.Duration.ZERO
-            .plusHours(wholePart(out, "hours"))
-            .plusMinutes(wholePart(out, "minutes"))
-            .plusNanos(secondsNanos(out))
+        val years = wholePart(out, "years")
+        val months = wholePart(out, "months")
+        val days = wholePart(out, "days")
+        val hours = wholePart(out, "hours")
+        val minutes = wholePart(out, "minutes")
+        val nanos = secondsNanos(out)
 
-          if (period.isZero) dduration.toString // covers the all-zero case: "PT0S"
-          else if (dduration.isZero) period.toString
-          else period.toString + dduration.toString.substring(1)
+        // ISO-8601 allows a single leading sign for the whole duration; parseParts produces
+        // (and accepts) that form, and toParts puts every part on the same side of zero for a
+        // negative duration, so prefer it here too rather than java.time's per-component signs
+        val negative = Seq(years, months, days, hours, minutes, nanos).forall(_ <= 0) &&
+          Seq(years, months, days, hours, minutes, nanos).exists(_ < 0)
+
+        try {
+          var period = Period.ZERO.plusYears(years).plusMonths(months).plusDays(days)
+          var dduration = java.time.Duration.ZERO.plusHours(hours).plusMinutes(minutes).plusNanos(nanos)
+          if (negative) {
+            period = period.negated()
+            dduration = dduration.negated()
+          }
+
+          val body =
+            if (period.isZero) dduration.toString // covers the all-zero case: "PT0S"
+            else if (dduration.isZero) period.toString
+            else period.toString + dduration.toString.substring(1)
+
+          if (negative) "-" + body else body
         } catch {
           case _: ArithmeticException | _: DateTimeException => Error.fail("Duration parts out of range")
         }

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Duration.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Duration.scala
@@ -10,6 +10,7 @@ package io.github.jam01.xtrasonnet.modules
 import sjsonnet.{Error, Val}
 import sjsonnet.functions.AbstractFunctionModule
 
+import java.math.MathContext
 import java.time.*
 import java.time.format.DateTimeParseException
 import scala.collection.mutable
@@ -18,6 +19,34 @@ object Duration extends AbstractFunctionModule {
   override def name: String = "duration"
 
   private val partNames = Array("years", "months", "days", "hours", "minutes", "seconds")
+  private val NanosPerSecond = BigDecimal(1000000000)
+
+  private def bigDecOf(num: Val.Num): BigDecimal = num match {
+    case i: Val.Int64 => BigDecimal(i.value)
+    case f: Val.Float64 => BigDecimal(f.value)
+    case d: Val.Dec128 => d.value
+  }
+
+  /** The given part as a whole number; every part but seconds rejects fractions rather than truncate. */
+  private def wholePart(parts: mutable.Map[String, Val], name: String): Long = parts.get(name) match {
+    case None => 0L
+    case Some(n: Val.Num) =>
+      val bd = bigDecOf(n)
+      if (!bd.isWhole) Error.fail("Expected a whole number for duration part " + name + ", got: " + n)
+      if (!bd.isValidLong) Error.fail("Duration part out of range: " + name)
+      bd.toLong
+    case Some(x) => Error.fail("Expected number for duration part " + name + ", got: " + x.prettyName)
+  }
+
+  /** The seconds part in nanoseconds, honoring fractional values. */
+  private def secondsNanos(parts: mutable.Map[String, Val]): Long = parts.get("seconds") match {
+    case None => 0L
+    case Some(n: Val.Num) =>
+      val nanos = (bigDecOf(n) * NanosPerSecond).setScale(0, BigDecimal.RoundingMode.HALF_UP)
+      if (!nanos.isValidLong) Error.fail("Duration part out of range: seconds")
+      nanos.toLong
+    case Some(x) => Error.fail("Expected number for duration part seconds, got: " + x.prettyName)
+  }
 
   val functions: Seq[(String, Val.Func)] = Seq(
     builtin("of", "obj") {
@@ -27,18 +56,23 @@ object Duration extends AbstractFunctionModule {
           if (!partNames.contains(key)) Error.fail("Unexpected duration part: " + key)
           out.addOne(key, obj.value(key, pos)(ev))
         }
-        val period = Period.ZERO
-          .plusYears(out.getOrElse("years", Val.Num(pos, 0)).asInt)
-          .plusMonths(out.getOrElse("months", Val.Num(pos, 0)).asInt)
-          .plusDays(out.getOrElse("days", Val.Num(pos, 0)).asInt)
-        val dduration = java.time.Duration.ZERO
-          .plusHours(out.getOrElse("hours", Val.Num(pos, 0)).asLong)
-          .plusMinutes(out.getOrElse("minutes", Val.Num(pos, 0)).asLong)
-          .plusSeconds(out.getOrElse("seconds", Val.Num(pos, 0)).asLong)
 
-        if (period.isZero) dduration.toString // covers the all-zero case: "PT0S"
-        else if (dduration.isZero) period.toString
-        else period.toString + dduration.toString.substring(1)
+        try {
+          val period = Period.ZERO
+            .plusYears(wholePart(out, "years"))
+            .plusMonths(wholePart(out, "months"))
+            .plusDays(wholePart(out, "days"))
+          val dduration = java.time.Duration.ZERO
+            .plusHours(wholePart(out, "hours"))
+            .plusMinutes(wholePart(out, "minutes"))
+            .plusNanos(secondsNanos(out))
+
+          if (period.isZero) dduration.toString // covers the all-zero case: "PT0S"
+          else if (dduration.isZero) period.toString
+          else period.toString + dduration.toString.substring(1)
+        } catch {
+          case _: ArithmeticException | _: DateTimeException => Error.fail("Duration parts out of range")
+        }
     },
 
     builtin("toParts", "str") {
@@ -46,12 +80,20 @@ object Duration extends AbstractFunctionModule {
         val (period, dduration) = parseParts(duration)
 
         val out = new java.util.LinkedHashMap[String, Val.Obj.Member]
+        val hours = dduration.toHours
+        val minutes = dduration.toMinutesPart
+        // exact seconds, so fractions like PT1.5S survive; getNano is a non-negative adjustment on getSeconds
+        val seconds = BigDecimal(dduration.getSeconds - hours * 3600 - minutes * 60) +
+          BigDecimal(dduration.getNano) / NanosPerSecond
+
         out.put("years", memberOf(Val.Num(pos, period.getYears)))
         out.put("months", memberOf(Val.Num(pos, period.getMonths)))
         out.put("days", memberOf(Val.Num(pos, period.getDays)))
-        out.put("hours", memberOf(Val.Num(pos, dduration.toHours)))
-        out.put("minutes", memberOf(Val.Num(pos, dduration.toMinutesPart)))
-        out.put("seconds", memberOf(Val.Num(pos, dduration.toSecondsPart)))
+        out.put("hours", memberOf(Val.Num(pos, hours)))
+        out.put("minutes", memberOf(Val.Num(pos, minutes)))
+        out.put("seconds", memberOf(
+          if (seconds.isWhole) Val.Num(pos, seconds.toLong)
+          else Val.Num(pos, new BigDecimal(seconds.bigDecimal, MathContext.DECIMAL128))))
 
         new Val.Obj(pos, out, false, null, null)
     }

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Duration.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Duration.scala
@@ -7,57 +7,72 @@ package io.github.jam01.xtrasonnet.modules
  * compliance with the Elastic License 2.0.
  */
 
-import sjsonnet.Val
+import sjsonnet.{Error, Val}
 import sjsonnet.functions.AbstractFunctionModule
 
 import java.time.*
+import java.time.format.DateTimeParseException
 import scala.collection.mutable
 
 object Duration extends AbstractFunctionModule {
   override def name: String = "duration"
-  
+
+  private val partNames = Array("years", "months", "days", "hours", "minutes", "seconds")
+
   val functions: Seq[(String, Val.Func)] = Seq(
     builtin("of", "obj") {
       (pos, ev, obj: Val.Obj) =>
         val out = mutable.Map[String, Val]()
-        obj.visibleKeyNames.foreach(key => out.addOne(key, obj.value(key, pos)(ev)))
-        Period.ZERO
+        obj.visibleKeyNames.foreach { key =>
+          if (!partNames.contains(key)) Error.fail("Unexpected duration part: " + key)
+          out.addOne(key, obj.value(key, pos)(ev))
+        }
+        val period = Period.ZERO
           .plusYears(out.getOrElse("years", Val.Num(pos, 0)).asInt)
           .plusMonths(out.getOrElse("months", Val.Num(pos, 0)).asInt)
           .plusDays(out.getOrElse("days", Val.Num(pos, 0)).asInt)
-          .toString +
-          java.time.Duration.ZERO
-            .plusHours(out.getOrElse("hours", Val.Num(pos, 0)).asLong)
-            .plusMinutes(out.getOrElse("minutes", Val.Num(pos, 0)).asLong)
-            .plusSeconds(out.getOrElse("seconds", Val.Num(pos, 0)).asLong)
-            .toString.substring(1)
+        val dduration = java.time.Duration.ZERO
+          .plusHours(out.getOrElse("hours", Val.Num(pos, 0)).asLong)
+          .plusMinutes(out.getOrElse("minutes", Val.Num(pos, 0)).asLong)
+          .plusSeconds(out.getOrElse("seconds", Val.Num(pos, 0)).asLong)
+
+        if (period.isZero) dduration.toString // covers the all-zero case: "PT0S"
+        else if (dduration.isZero) period.toString
+        else period.toString + dduration.toString.substring(1)
     },
 
     builtin("toParts", "str") {
       (pos, _, duration: String) =>
-        val out = new java.util.LinkedHashMap[String, Val.Obj.Member]
-        val timeIdx = duration.indexOf('T')
-        var period: Period = null
-        var dduration: Duration = null
+        val negative = duration.startsWith("-")
+        val abs = if (negative || duration.startsWith("+")) duration.substring(1) else duration
+        val timeIdx = abs.indexOf('T')
+        var period = Period.ZERO
+        var dduration = java.time.Duration.ZERO
 
-        if (timeIdx != -1) {
-          dduration = java.time.Duration.parse("P" + duration.substring(timeIdx))
-          period = Period.parse(duration.substring(0, timeIdx))
-        } else {
-          period = Period.parse(duration)
+        try {
+          if (timeIdx != -1) {
+            dduration = java.time.Duration.parse("P" + abs.substring(timeIdx))
+            val datePart = abs.substring(0, timeIdx)
+            if (datePart != "P") period = Period.parse(datePart) // "P" alone means no date components
+          } else {
+            period = Period.parse(abs)
+          }
+        } catch {
+          case _: DateTimeParseException => Error.fail("Invalid ISO-8601 duration: " + duration)
         }
 
+        if (negative) {
+          period = period.negated()
+          dduration = dduration.negated()
+        }
+
+        val out = new java.util.LinkedHashMap[String, Val.Obj.Member]
         out.put("years", memberOf(Val.Num(pos, period.getYears)))
         out.put("months", memberOf(Val.Num(pos, period.getMonths)))
         out.put("days", memberOf(Val.Num(pos, period.getDays)))
-        if (dduration != null) { // TODO: probably super inefficient
-          val hours = dduration.toHours
-          val minutes = dduration.minusHours(hours).toMinutes
-          val seconds = dduration.minusHours(hours).minusMinutes(minutes).toSeconds
-          out.put("hours", memberOf(Val.Num(pos, hours)))
-          out.put("minutes", memberOf(Val.Num(pos, minutes)))
-          out.put("seconds", memberOf(Val.Num(pos, seconds)))
-        }
+        out.put("hours", memberOf(Val.Num(pos, dduration.toHours)))
+        out.put("minutes", memberOf(Val.Num(pos, dduration.toMinutesPart)))
+        out.put("seconds", memberOf(Val.Num(pos, dduration.toSecondsPart)))
 
         new Val.Obj(pos, out, false, null, null)
     }

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Duration.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Duration.scala
@@ -43,28 +43,7 @@ object Duration extends AbstractFunctionModule {
 
     builtin("toParts", "str") {
       (pos, _, duration: String) =>
-        val negative = duration.startsWith("-")
-        val abs = if (negative || duration.startsWith("+")) duration.substring(1) else duration
-        val timeIdx = abs.indexOf('T')
-        var period = Period.ZERO
-        var dduration = java.time.Duration.ZERO
-
-        try {
-          if (timeIdx != -1) {
-            dduration = java.time.Duration.parse("P" + abs.substring(timeIdx))
-            val datePart = abs.substring(0, timeIdx)
-            if (datePart != "P") period = Period.parse(datePart) // "P" alone means no date components
-          } else {
-            period = Period.parse(abs)
-          }
-        } catch {
-          case _: DateTimeParseException => Error.fail("Invalid ISO-8601 duration: " + duration)
-        }
-
-        if (negative) {
-          period = period.negated()
-          dduration = dduration.negated()
-        }
+        val (period, dduration) = parseParts(duration)
 
         val out = new java.util.LinkedHashMap[String, Val.Obj.Member]
         out.put("years", memberOf(Val.Num(pos, period.getYears)))
@@ -77,4 +56,39 @@ object Duration extends AbstractFunctionModule {
         new Val.Obj(pos, out, false, null, null)
     }
   )
+
+  /**
+   * Parses an ISO-8601 duration into its date and time components; a leading sign applies to both.
+   *
+   * Handles the shapes java.time cannot parse in one call: combined date-and-time strings, time-only
+   * strings ("PT4H"), and a leading sign, failing with an evaluation error for anything malformed.
+   */
+  def parseParts(duration: String): (Period, java.time.Duration) = {
+    val negative = duration.startsWith("-")
+    val abs = if (negative || duration.startsWith("+")) duration.substring(1) else duration
+    val timeIdx = abs.indexOf('T')
+    var period = Period.ZERO
+    var dduration = java.time.Duration.ZERO
+
+    try {
+      if (timeIdx != -1) {
+        dduration = java.time.Duration.parse("P" + abs.substring(timeIdx))
+        val datePart = abs.substring(0, timeIdx)
+        if (datePart != "P") period = Period.parse(datePart) // "P" alone means no date components
+      } else {
+        period = Period.parse(abs)
+      }
+
+      if (negative) {
+        period = period.negated()
+        dduration = dduration.negated()
+      }
+    } catch {
+      // ArithmeticException covers negation overflow of a component at the numeric range's edge
+      case _: DateTimeParseException | _: ArithmeticException =>
+        Error.fail("Invalid ISO-8601 duration: " + duration)
+    }
+
+    (period, dduration)
+  }
 }

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Objects.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Objects.scala
@@ -43,7 +43,7 @@ object Objects extends AbstractFunctionModule {
       "funcIdL" -> null,
       "funcIdR" -> null,
       "funcJoin" -> Val.False(position)) { (args, pos, ev) =>
-      eqJoin(args, pos, ev, unmatchedLeft = false, unmatchedRight = false)
+      eqJoin(args, pos, ev, JoinKind.Inner)
     },
 
     builtinWithDefaults("leftEqJoin",
@@ -52,7 +52,7 @@ object Objects extends AbstractFunctionModule {
       "funcIdL" -> null,
       "funcIdR" -> null,
       "funcJoin" -> Val.False(position)) { (args, pos, ev) =>
-      eqJoin(args, pos, ev, unmatchedLeft = true, unmatchedRight = false)
+      eqJoin(args, pos, ev, JoinKind.Left)
     },
 
     builtinWithDefaults("fullEqJoin",
@@ -61,7 +61,7 @@ object Objects extends AbstractFunctionModule {
       "funcIdL" -> null,
       "funcIdR" -> null,
       "funcJoin" -> Val.False(position)) { (args, pos, ev) =>
-      eqJoin(args, pos, ev, unmatchedLeft = true, unmatchedRight = true)
+      eqJoin(args, pos, ev, JoinKind.Full)
     },
 
     builtinWithDefaults("fromArray",
@@ -117,6 +117,14 @@ object Objects extends AbstractFunctionModule {
     }
   )
 
+  /** Which rows eqJoin emits besides the matched pairs; the only three combinations any builtin defines. */
+  private sealed trait JoinKind
+  private object JoinKind {
+    case object Inner extends JoinKind // matched pairs only
+    case object Left extends JoinKind // + unmatched left rows
+    case object Full extends JoinKind // + unmatched left and right rows
+  }
+
   /**
    * The hash-join core behind inner/left/fullEqJoin, differing only in which unmatched rows they emit.
    *
@@ -124,8 +132,10 @@ object Objects extends AbstractFunctionModule {
    * right matches in right order, one row per match via a shallow merge or funcJoin -- and, when
    * unmatched right rows are emitted, those appended in their original order.
    */
-  private def eqJoin(args: Array[Val], pos: Position, ev: EvalScope,
-                     unmatchedLeft: Boolean, unmatchedRight: Boolean): Val = {
+  private def eqJoin(args: Array[Val], pos: Position, ev: EvalScope, kind: JoinKind): Val = {
+    val unmatchedLeft = kind != JoinKind.Inner
+    val unmatchedRight = kind == JoinKind.Full
+
     val left = args(0).asArr
     val right = args(1).asArr
     val funcIdL = args(2).asFunc
@@ -136,19 +146,19 @@ object Objects extends AbstractFunctionModule {
       case x => Error.fail("Expected function, got: " + x.prettyName)
     }
 
-    // 1. Index the RIGHT side by key, keeping each row's key for the unmatched pass
+    // 1. Index the RIGHT side by key; unmatchedRight also needs each row's key for the unmatched pass
     val rightHash = new util.HashMap[String, ArrayBuffer[Val.Obj]]()
-    val rightKeys = new Array[String](right.length)
+    val rightKeys = if (unmatchedRight) new Array[String](right.length) else null
     var i = 0
     while (i < right.length) {
       val k = keyFrom(funcIdR.apply1(right.asLazyArray(i), funcIdR.pos)(ev, TailstrictModeDisabled))
       rightHash.computeIfAbsent(k, newArrBuff).addOne(right.force(i).asObj)
-      rightKeys(i) = k
+      if (unmatchedRight) rightKeys(i) = k
       i += 1
     }
 
     val result = new ArrayBuffer[Val]()
-    val joinedKeys = new util.HashSet[String]()
+    val joinedKeys = if (unmatchedRight) new util.HashSet[String]() else null
 
     // 2. Iterate the LEFT side in original order
     i = 0
@@ -158,7 +168,7 @@ object Objects extends AbstractFunctionModule {
 
       val matches = rightHash.get(k)
       if (matches != null) {
-        joinedKeys.add(k)
+        if (unmatchedRight) joinedKeys.add(k)
         matches.foreach { rightObj =>
           result.addOne(
             if (funcJoin == null) leftObj.addSuper(pos, rightObj).asObj

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Objects.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Objects.scala
@@ -15,7 +15,6 @@ import sjsonnet.{Error, EvalScope, FileScope, TailstrictModeDisabled, Val}
 
 import java.util
 import scala.collection.mutable.ArrayBuffer
-import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 object Objects extends AbstractFunctionModule {
   override def name: String = "objects"
@@ -67,7 +66,7 @@ object Objects extends AbstractFunctionModule {
 
       i = 0
       while (i < right.length) {
-        val k = keyFrom(funcIdR.apply1(right.asLazyArray(i), funcIdL.pos)(ev, TailstrictModeDisabled))
+        val k = keyFrom(funcIdR.apply1(right.asLazyArray(i), funcIdR.pos)(ev, TailstrictModeDisabled))
         if (leftHash.containsKey(k)) {
           leftHash.get(k).foreach(obj =>
             out.addOne(
@@ -155,49 +154,55 @@ object Objects extends AbstractFunctionModule {
         case f: Val.Func => f
         case x => Error.fail("Expected function, got: " + x.prettyName)
       }
-      val leftHash = new util.HashMap[String, ArrayBuffer[Val.Obj]]()
-      val bothHash = new util.HashMap[String, ArrayBuffer[Val.Obj]]()
-      val leftUnjoined = new util.HashSet[String]()
 
+      // 1. Index the RIGHT side by key, keeping each row's key for the unmatched pass
+      val rightHash = new util.HashMap[String, ArrayBuffer[Val.Obj]]()
+      val rightKeys = new Array[String](right.length)
       var i = 0
-      while (i < left.length) { // computing keys on the left with the corresponding array of values
-        val k = keyFrom(funcIdL.apply1(left.asLazyArray(i), funcIdL.pos)(ev, TailstrictModeDisabled))
-        val toAdd = left.force(i).asObj
-        val arr = leftHash.computeIfAbsent(k, newArrBuff).addOne(toAdd)
-
-        // no custom func, already moving to both in case not to be joined
-        if (funcJoin == null) bothHash.put(k, arr)
-        leftUnjoined.add(k)
-        i = i + 1
+      while (i < right.length) {
+        val k = keyFrom(funcIdR.apply1(right.asLazyArray(i), funcIdR.pos)(ev, TailstrictModeDisabled))
+        rightHash.computeIfAbsent(k, newArrBuff).addOne(right.force(i).asObj)
+        rightKeys(i) = k
+        i += 1
       }
 
+      val result = new ArrayBuffer[Val]()
+      val joinedKeys = new util.HashSet[String]()
+
+      // 2. Iterate the LEFT side in original order: joined rows where a key matches, plain left rows otherwise
       i = 0
-      while (i < right.length) { // computing keys on the right
-        val k = keyFrom(funcIdR.apply1(right.asLazyArray(i), funcIdL.pos)(ev, TailstrictModeDisabled))
-        if (leftHash.containsKey(k)) { // if also in left join them into bothHash
-          leftHash.get(k).foreach(obj => {
-            if (leftUnjoined.remove(k)) bothHash.remove(k) // 1st time seeing this one, clear it to join
-            bothHash.computeIfAbsent(k, newArrBuff).addOne(
-              if (funcJoin == null) obj.asObj.addSuper(pos, right.force(i).asObj).asObj
-              else funcJoin.asFunc.apply2(obj, right.force(i), funcJoin.pos)(ev, TailstrictModeDisabled).asObj
-            )
-          })
-        } else { // else add it to bothHash
-          val toAdd =
-            if (funcJoin == null) right.force(i).asObj
-            else funcJoin.asFunc.apply2(emptyObj, right.force(i).asObj, funcJoin.pos)(ev, TailstrictModeDisabled).asObj
-          bothHash.computeIfAbsent(k, _ => new ArrayBuffer[Obj]()).addOne(toAdd)
-        }
+      while (i < left.length) {
+        val leftObj = left.force(i).asObj
+        val k = keyFrom(funcIdL.apply1(left.asLazyArray(i), funcIdL.pos)(ev, TailstrictModeDisabled))
 
-        i = i + 1
+        val matches = rightHash.get(k)
+        if (matches != null) {
+          joinedKeys.add(k)
+          matches.foreach { rightObj =>
+            result.addOne(
+              if (funcJoin == null) leftObj.addSuper(pos, rightObj).asObj
+              else funcJoin.asFunc.apply2(leftObj, rightObj, funcJoin.pos)(ev, TailstrictModeDisabled).asObj)
+          }
+        } else {
+          result.addOne(
+            if (funcJoin == null) leftObj
+            else funcJoin.asFunc.apply2(leftObj, emptyObj, funcJoin.pos)(ev, TailstrictModeDisabled).asObj)
+        }
+        i += 1
       }
 
-      // if custom join func, apply to the remaining unjoined ones (otherwise already in bothHash)
-      if (funcJoin != null) leftUnjoined.forEach(k => bothHash.put(k, leftHash.get(k).map(obj =>
-        funcJoin.asFunc.apply2(obj, emptyObj, funcJoin.pos)(ev, TailstrictModeDisabled).asObj
-      )))
+      // 3. Append the unmatched RIGHT rows in their original order
+      i = 0
+      while (i < right.length) {
+        if (!joinedKeys.contains(rightKeys(i))) {
+          result.addOne(
+            if (funcJoin == null) right.force(i).asObj
+            else funcJoin.asFunc.apply2(emptyObj, right.asLazyArray(i), funcJoin.pos)(ev, TailstrictModeDisabled).asObj)
+        }
+        i += 1
+      }
 
-      Val.Arr(pos, bothHash.values().asScala.flatten.toArray)
+      Val.Arr(pos, result.toArray)
     },
 
     builtinWithDefaults("fromArray",

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Objects.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Objects.scala
@@ -11,7 +11,7 @@ import io.github.jam01.xtrasonnet.spi.Library.{emptyObj, keyFrom}
 import sjsonnet.Expr.Member.Visibility
 import sjsonnet.Val.Obj
 import sjsonnet.functions.AbstractFunctionModule
-import sjsonnet.{Error, EvalScope, FileScope, TailstrictModeDisabled, Val}
+import sjsonnet.{Error, EvalScope, FileScope, Position, TailstrictModeDisabled, Val}
 
 import java.util
 import scala.collection.mutable.ArrayBuffer
@@ -43,43 +43,7 @@ object Objects extends AbstractFunctionModule {
       "funcIdL" -> null,
       "funcIdR" -> null,
       "funcJoin" -> Val.False(position)) { (args, pos, ev) =>
-
-      val left = args(0).asArr
-      val right = args(1).asArr
-      val funcIdL = args(2).asFunc
-      val funcIdR = args(3).asFunc
-      val funcJoin = args(4) match {
-        case _: Val.False => null
-        case f: Val.Func => f
-        case x => Error.fail("Expected function, got: " + x.prettyName)
-      }
-      val leftHash = new util.HashMap[String, ArrayBuffer[Val.Obj]]()
-      val out = new ArrayBuffer[Val.Obj]()
-
-      var i = 0
-      while (i < left.length) {
-        val k = keyFrom(funcIdL.apply1(left.asLazyArray(i), funcIdL.pos)(ev, TailstrictModeDisabled))
-        if (leftHash.containsKey(k)) leftHash.put(k, leftHash.get(k).addOne(left.force(i).asObj))
-        else leftHash.put(k, ArrayBuffer[Obj](left.force(i).asObj))
-        i = i + 1
-      }
-
-      i = 0
-      while (i < right.length) {
-        val k = keyFrom(funcIdR.apply1(right.asLazyArray(i), funcIdR.pos)(ev, TailstrictModeDisabled))
-        if (leftHash.containsKey(k)) {
-          leftHash.get(k).foreach(obj =>
-            out.addOne(
-              if (funcJoin == null) obj.asObj.addSuper(pos, right.force(i).asObj).asObj
-              else funcJoin.asFunc.apply2(obj, right.force(i), funcJoin.pos)(ev, TailstrictModeDisabled).asObj
-            )
-          )
-        }
-
-        i = i + 1
-      }
-
-      Val.Arr(pos, out.toArray)
+      eqJoin(args, pos, ev, unmatchedLeft = false, unmatchedRight = false)
     },
 
     builtinWithDefaults("leftEqJoin",
@@ -88,54 +52,7 @@ object Objects extends AbstractFunctionModule {
       "funcIdL" -> null,
       "funcIdR" -> null,
       "funcJoin" -> Val.False(position)) { (args, pos, ev) =>
-
-      val left = args(0).asArr
-      val right = args(1).asArr
-      val funcIdL = args(2).asFunc
-      val funcIdR = args(3).asFunc
-      val funcJoin = args(4) match {
-        case _: Val.False => null
-        case f: Val.Func => f
-        case x => Error.fail("Expected function, got: " + x.prettyName)
-      }
-
-      // 1. Index the RIGHT side so we can look them up by key
-      val rightHash = new util.HashMap[String, ArrayBuffer[Val.Obj]]()
-      var i = 0
-      while (i < right.length) {
-        val k = keyFrom(funcIdR.apply1(right.asLazyArray(i), funcIdR.pos)(ev, TailstrictModeDisabled))
-        rightHash.computeIfAbsent(k, _ => new ArrayBuffer[Val.Obj]()).addOne(right.force(i).asObj)
-        i += 1
-      }
-
-      val result = new ArrayBuffer[Val]()
-
-      // 2. Iterate through the LEFT side in their original order
-      i = 0
-      while (i < left.length) {
-        val leftObj = left.force(i).asObj
-        val k = keyFrom(funcIdL.apply1(left.asLazyArray(i), funcIdL.pos)(ev, TailstrictModeDisabled))
-
-        val matches = rightHash.get(k)
-        if (matches != null && !matches.isEmpty) {
-          // For every match in orders, create a joined row
-          matches.foreach { rightObj =>
-            val joined = if (funcJoin == null) leftObj.addSuper(pos, rightObj).asObj
-            else
-              funcJoin.asFunc.apply2(leftObj, rightObj, funcJoin.pos)(ev, TailstrictModeDisabled).asObj
-            result.addOne(joined)
-          }
-        } else {
-          // No match found? Still add the left object (Left Join behavior)
-          val unjoined = if (funcJoin == null) leftObj
-          else
-            funcJoin.asFunc.apply2(leftObj, emptyObj, funcJoin.pos)(ev, TailstrictModeDisabled).asObj
-          result.addOne(unjoined)
-        }
-        i += 1
-      }
-
-      Val.Arr(pos, result.toArray)
+      eqJoin(args, pos, ev, unmatchedLeft = true, unmatchedRight = false)
     },
 
     builtinWithDefaults("fullEqJoin",
@@ -144,65 +61,7 @@ object Objects extends AbstractFunctionModule {
       "funcIdL" -> null,
       "funcIdR" -> null,
       "funcJoin" -> Val.False(position)) { (args, pos, ev) =>
-
-      val left = args(0).asArr
-      val right = args(1).asArr
-      val funcIdL = args(2).asFunc
-      val funcIdR = args(3).asFunc
-      val funcJoin = args(4) match {
-        case _: Val.False => null
-        case f: Val.Func => f
-        case x => Error.fail("Expected function, got: " + x.prettyName)
-      }
-
-      // 1. Index the RIGHT side by key, keeping each row's key for the unmatched pass
-      val rightHash = new util.HashMap[String, ArrayBuffer[Val.Obj]]()
-      val rightKeys = new Array[String](right.length)
-      var i = 0
-      while (i < right.length) {
-        val k = keyFrom(funcIdR.apply1(right.asLazyArray(i), funcIdR.pos)(ev, TailstrictModeDisabled))
-        rightHash.computeIfAbsent(k, newArrBuff).addOne(right.force(i).asObj)
-        rightKeys(i) = k
-        i += 1
-      }
-
-      val result = new ArrayBuffer[Val]()
-      val joinedKeys = new util.HashSet[String]()
-
-      // 2. Iterate the LEFT side in original order: joined rows where a key matches, plain left rows otherwise
-      i = 0
-      while (i < left.length) {
-        val leftObj = left.force(i).asObj
-        val k = keyFrom(funcIdL.apply1(left.asLazyArray(i), funcIdL.pos)(ev, TailstrictModeDisabled))
-
-        val matches = rightHash.get(k)
-        if (matches != null) {
-          joinedKeys.add(k)
-          matches.foreach { rightObj =>
-            result.addOne(
-              if (funcJoin == null) leftObj.addSuper(pos, rightObj).asObj
-              else funcJoin.asFunc.apply2(leftObj, rightObj, funcJoin.pos)(ev, TailstrictModeDisabled).asObj)
-          }
-        } else {
-          result.addOne(
-            if (funcJoin == null) leftObj
-            else funcJoin.asFunc.apply2(leftObj, emptyObj, funcJoin.pos)(ev, TailstrictModeDisabled).asObj)
-        }
-        i += 1
-      }
-
-      // 3. Append the unmatched RIGHT rows in their original order
-      i = 0
-      while (i < right.length) {
-        if (!joinedKeys.contains(rightKeys(i))) {
-          result.addOne(
-            if (funcJoin == null) right.force(i).asObj
-            else funcJoin.asFunc.apply2(emptyObj, right.asLazyArray(i), funcJoin.pos)(ev, TailstrictModeDisabled).asObj)
-        }
-        i += 1
-      }
-
-      Val.Arr(pos, result.toArray)
+      eqJoin(args, pos, ev, unmatchedLeft = true, unmatchedRight = true)
     },
 
     builtinWithDefaults("fromArray",
@@ -257,6 +116,78 @@ object Objects extends AbstractFunctionModule {
       new Val.Obj(pos, m, false, null, null).asInstanceOf[Val]
     }
   )
+
+  /**
+   * The hash-join core behind inner/left/fullEqJoin, differing only in which unmatched rows they emit.
+   *
+   * Rows come out in a deterministic order: left rows in their original order -- each expanded to its
+   * right matches in right order, one row per match via a shallow merge or funcJoin -- and, when
+   * unmatched right rows are emitted, those appended in their original order.
+   */
+  private def eqJoin(args: Array[Val], pos: Position, ev: EvalScope,
+                     unmatchedLeft: Boolean, unmatchedRight: Boolean): Val = {
+    val left = args(0).asArr
+    val right = args(1).asArr
+    val funcIdL = args(2).asFunc
+    val funcIdR = args(3).asFunc
+    val funcJoin = args(4) match {
+      case _: Val.False => null
+      case f: Val.Func => f
+      case x => Error.fail("Expected function, got: " + x.prettyName)
+    }
+
+    // 1. Index the RIGHT side by key, keeping each row's key for the unmatched pass
+    val rightHash = new util.HashMap[String, ArrayBuffer[Val.Obj]]()
+    val rightKeys = new Array[String](right.length)
+    var i = 0
+    while (i < right.length) {
+      val k = keyFrom(funcIdR.apply1(right.asLazyArray(i), funcIdR.pos)(ev, TailstrictModeDisabled))
+      rightHash.computeIfAbsent(k, newArrBuff).addOne(right.force(i).asObj)
+      rightKeys(i) = k
+      i += 1
+    }
+
+    val result = new ArrayBuffer[Val]()
+    val joinedKeys = new util.HashSet[String]()
+
+    // 2. Iterate the LEFT side in original order
+    i = 0
+    while (i < left.length) {
+      val leftObj = left.force(i).asObj
+      val k = keyFrom(funcIdL.apply1(left.asLazyArray(i), funcIdL.pos)(ev, TailstrictModeDisabled))
+
+      val matches = rightHash.get(k)
+      if (matches != null) {
+        joinedKeys.add(k)
+        matches.foreach { rightObj =>
+          result.addOne(
+            if (funcJoin == null) leftObj.addSuper(pos, rightObj).asObj
+            else funcJoin.apply2(leftObj, rightObj, funcJoin.pos)(ev, TailstrictModeDisabled).asObj)
+        }
+      } else if (unmatchedLeft) {
+        result.addOne(
+          if (funcJoin == null) leftObj
+          else funcJoin.apply2(leftObj, emptyObj, funcJoin.pos)(ev, TailstrictModeDisabled).asObj)
+      }
+      i += 1
+    }
+
+    // 3. Append the unmatched RIGHT rows in their original order
+    if (unmatchedRight) {
+      i = 0
+      while (i < right.length) {
+        if (!joinedKeys.contains(rightKeys(i))) {
+          val rightObj = right.force(i).asObj
+          result.addOne(
+            if (funcJoin == null) rightObj
+            else funcJoin.apply2(emptyObj, rightObj, funcJoin.pos)(ev, TailstrictModeDisabled).asObj)
+        }
+        i += 1
+      }
+    }
+
+    Val.Arr(pos, result.toArray)
+  }
 
   private def distinctBy(obj: Val.Obj, func: Val.Func, ev: EvalScope): Val = {
     val pos = func.pos

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Strings.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Strings.scala
@@ -7,10 +7,10 @@ package io.github.jam01.xtrasonnet.modules
  * compliance with the Elastic License 2.0.
  */
 
+import io.github.jam01.xtrasonnet.util.ConcurrentLruCache
 import sjsonnet.functions.AbstractFunctionModule
 import sjsonnet.{Error, Lazy, Position, Val}
 
-import java.util.concurrent.ConcurrentHashMap
 import java.util.regex.{Matcher, Pattern, PatternSyntaxException}
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -346,20 +346,12 @@ object Strings extends AbstractFunctionModule {
   )
 
   // shared across all Transformers; Pattern is immutable and thread-safe
-  private val patternCache = new ConcurrentHashMap[String, Pattern]()
+  private val patternCache = new ConcurrentLruCache[String, Pattern](1024, regex =>
+    try Pattern.compile(regex) catch {
+      case e: PatternSyntaxException => Error.fail("Invalid regular expression: " + e.getMessage)
+    })
 
-  private def compile(regex: String): Pattern = {
-    val cached = patternCache.get(regex)
-    if (cached != null) return cached
-
-    val compiled =
-      try Pattern.compile(regex) catch {
-        case e: PatternSyntaxException => Error.fail("Invalid regular expression: " + e.getMessage)
-      }
-    if (patternCache.size >= 1024) patternCache.clear() // crude bound for scripts that generate regexes
-    patternCache.putIfAbsent(regex, compiled)
-    compiled
-  }
+  private def compile(regex: String): Pattern = patternCache.get(regex)
 
   /** The current match as [entire match, capture groups...], null for groups that didn't participate. */
   private def groupsOf(matcher: Matcher, pos: Position): Array[Lazy] = {

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Strings.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Strings.scala
@@ -8,10 +8,12 @@ package io.github.jam01.xtrasonnet.modules
  */
 
 import sjsonnet.functions.AbstractFunctionModule
-import sjsonnet.{Error, Val}
+import sjsonnet.{Error, Lazy, Position, Val}
 
 import java.text.DecimalFormat
+import java.util.regex.{Matcher, Pattern, PatternSyntaxException}
 import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 
 object Strings extends AbstractFunctionModule {
   override def name: String = "strings"
@@ -322,6 +324,40 @@ object Strings extends AbstractFunctionModule {
       (_, _, str: String, wrapper: String) => wrapper + str + wrapper
     },
 
-    // todo: regex functions -- scan, match, matches -- are still missing from this module
+    builtin("match", "str", "regex") {
+      (pos, _, str: String, regex: String) =>
+        val matcher = compile(regex).matcher(str)
+        if (!matcher.matches()) Val.Null(pos)
+        else Val.Arr(pos, groupsOf(matcher, pos))
+    },
+
+    builtin("matches", "str", "regex") {
+      (_, _, str: String, regex: String) => compile(regex).matcher(str).matches()
+    },
+
+    builtin("scan", "str", "regex") {
+      (pos, _, str: String, regex: String) =>
+        val matcher = compile(regex).matcher(str)
+        val out = new ArrayBuffer[Lazy]()
+        while (matcher.find()) out.append(Val.Arr(pos, groupsOf(matcher, pos)))
+        Val.Arr(pos, out.toArray)
+    }
   )
+
+  private def compile(regex: String): Pattern =
+    try Pattern.compile(regex) catch {
+      case e: PatternSyntaxException => Error.fail("Invalid regular expression: " + e.getMessage)
+    }
+
+  /** The current match as [entire match, capture groups...], null for groups that didn't participate. */
+  private def groupsOf(matcher: Matcher, pos: Position): Array[Lazy] = {
+    val groups = new Array[Lazy](matcher.groupCount() + 1)
+    var i = 0
+    while (i <= matcher.groupCount()) {
+      val group = matcher.group(i)
+      groups(i) = if (group == null) Val.Null(pos) else Val.Str(pos, group)
+      i = i + 1
+    }
+    groups
+  }
 }

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Strings.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Strings.scala
@@ -10,6 +10,7 @@ package io.github.jam01.xtrasonnet.modules
 import sjsonnet.functions.AbstractFunctionModule
 import sjsonnet.{Error, Lazy, Materializer, Position, Val}
 
+import java.util.concurrent.ConcurrentHashMap
 import java.util.regex.{Matcher, Pattern, PatternSyntaxException}
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -341,10 +342,21 @@ object Strings extends AbstractFunctionModule {
     }
   )
 
-  private def compile(regex: String): Pattern =
-    try Pattern.compile(regex) catch {
-      case e: PatternSyntaxException => Error.fail("Invalid regular expression: " + e.getMessage)
-    }
+  // shared across all Transformers; Pattern is immutable and thread-safe
+  private val patternCache = new ConcurrentHashMap[String, Pattern]()
+
+  private def compile(regex: String): Pattern = {
+    val cached = patternCache.get(regex)
+    if (cached != null) return cached
+
+    val compiled =
+      try Pattern.compile(regex) catch {
+        case e: PatternSyntaxException => Error.fail("Invalid regular expression: " + e.getMessage)
+      }
+    if (patternCache.size >= 1024) patternCache.clear() // crude bound for scripts that generate regexes
+    patternCache.putIfAbsent(regex, compiled)
+    compiled
+  }
 
   /** The current match as [entire match, capture groups...], null for groups that didn't participate. */
   private def groupsOf(matcher: Matcher, pos: Position): Array[Lazy] = {

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Strings.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Strings.scala
@@ -8,7 +8,7 @@ package io.github.jam01.xtrasonnet.modules
  */
 
 import sjsonnet.functions.AbstractFunctionModule
-import sjsonnet.{Error, Lazy, Materializer, Position, Val}
+import sjsonnet.{Error, Lazy, Position, Val}
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.regex.{Matcher, Pattern, PatternSyntaxException}
@@ -164,10 +164,13 @@ object Strings extends AbstractFunctionModule {
     },
 
     builtin("leftPad", "str", "offset", "pad") {
-      (_, ev, str: Val, size: Int, pad: String) =>
+      (_, _, str: Val, size: Int, pad: String) =>
         str match {
           case str: Val.Str => padStart(str.value, size, pad)
-          case x: Val.Num => padStart(Materializer.stringify(x)(ev), size, pad)
+          // route through BigDecimal's plain string form: Val.Num's own toString (and thus
+          // Materializer.stringify) uses scientific notation for very small/large magnitudes,
+          // which isn't a valid padded numeric string
+          case x: Val.Num => padStart(BigDecimal(x.toString).bigDecimal.toPlainString, size, pad)
           case x => Error.fail("Expected String, got: " + x.prettyName)
         }
     },
@@ -226,10 +229,10 @@ object Strings extends AbstractFunctionModule {
     },
 
     builtin("rightPad", "str", "offset", "pad") {
-      (_, ev, value: Val, offset: Int, pad: String) =>
+      (_, _, value: Val, offset: Int, pad: String) =>
         value match {
           case str: Val.Str => str.value.padTo(offset, padChar(pad))
-          case x: Val.Num => Materializer.stringify(x)(ev).padTo(offset, padChar(pad))
+          case x: Val.Num => BigDecimal(x.toString).bigDecimal.toPlainString.padTo(offset, padChar(pad))
           case x => Error.fail("Expected String, got: " + x.prettyName)
         }
     },

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Strings.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/modules/Strings.scala
@@ -8,9 +8,8 @@ package io.github.jam01.xtrasonnet.modules
  */
 
 import sjsonnet.functions.AbstractFunctionModule
-import sjsonnet.{Error, Lazy, Position, Val}
+import sjsonnet.{Error, Lazy, Materializer, Position, Val}
 
-import java.text.DecimalFormat
 import java.util.regex.{Matcher, Pattern, PatternSyntaxException}
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -164,11 +163,10 @@ object Strings extends AbstractFunctionModule {
     },
 
     builtin("leftPad", "str", "offset", "pad") {
-      (_, _, str: Val, size: Int, pad: String) =>
+      (_, ev, str: Val, size: Int, pad: String) =>
         str match {
           case str: Val.Str => padStart(str.value, size, pad)
-          //TODO change to use sjsonnet's Format and DecimalFormat
-          case x: Val.Num => padStart(new DecimalFormat("0.#").format(x.asInt), size, pad)
+          case x: Val.Num => padStart(Materializer.stringify(x)(ev), size, pad)
           case x => Error.fail("Expected String, got: " + x.prettyName)
         }
     },
@@ -227,11 +225,10 @@ object Strings extends AbstractFunctionModule {
     },
 
     builtin("rightPad", "str", "offset", "pad") {
-      (_, _, value: Val, offset: Int, pad: String) =>
+      (_, ev, value: Val, offset: Int, pad: String) =>
         value match {
           case str: Val.Str => str.value.padTo(offset, padChar(pad))
-          //TODO change to use sjsonnet's Format and DecimalFormat
-          case x: Val.Num => new DecimalFormat("0.#").format(x.asInt).padTo(offset, padChar(pad))
+          case x: Val.Num => Materializer.stringify(x)(ev).padTo(offset, padChar(pad))
           case x => Error.fail("Expected String, got: " + x.prettyName)
         }
     },

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/plugins/xml/BadgerFishHandler.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/plugins/xml/BadgerFishHandler.scala
@@ -32,6 +32,9 @@ package io.github.jam01.xtrasonnet.plugins.xml
  * - de7029978b65a012dfdb8dd32b598e99a9c7708a: renamed currentNS to declaredXmlns, only start new xmlns context when
  *    xmlns found, use new NamespaceDeclarations
  * - 487f7939b08dfb9e75aa3ed4728a9e23e89d57dd: map the empty default-namespace prefix to the _def key
+ * - track per-element whether that element's start pushed a namespace context, so its end pops the
+ *   matching one; declaredXmlns.isEmpty was an unreliable proxy once a childless descendant closed
+ *   after its parent, since declaredXmlns wasn't repopulated to signal the parent's own pop
  */
 
 import io.github.jam01.xtrasonnet.plugins.DefaultXMLPlugin
@@ -61,6 +64,9 @@ class BadgerFishHandler(params: EffectiveParams) extends DefaultHandler2 {
   private var startContext = true // start a new context at the first xmlns declaration in doc
   private val overrides = new NamespaceDeclarations(params.declarations.asJava)
   private var declaredXmlns: util.LinkedHashMap[String, Val.Obj.Member] = util.LinkedHashMap()
+  // per-element record of whether that element's own start pushed a namespace context, so its end
+  // pops the matching one regardless of whether descendants pushed (and cleared declaredXmlns) too
+  private val pushedContext = new mutable.Stack[Boolean]
 
   // root
   badgerStack.push(BadgerFish(mutable.LinkedHashMap.empty))
@@ -89,7 +95,9 @@ class BadgerFishHandler(params: EffectiveParams) extends DefaultHandler2 {
 
     val current = mutable.LinkedHashMap.empty[String, BFValue] // builder for this element
 
-    if (!declaredXmlns.isEmpty) {
+    val pushedForThisElement = !declaredXmlns.isEmpty
+    pushedContext.push(pushedForThisElement)
+    if (pushedForThisElement) {
       current.put(params.xmlnsKey, BFSingle(Val.Obj(dummyPos, declaredXmlns, false, null, null)))
       declaredXmlns = new util.LinkedHashMap()
     }
@@ -186,7 +194,7 @@ class BadgerFishHandler(params: EffectiveParams) extends DefaultHandler2 {
     }
 
     capture = badgerStack.size != 1 // stop capturing at root level
-    if (!declaredXmlns.isEmpty) { // some xmlns were found
+    if (pushedContext.pop()) { // pop only if this element's own start pushed a context
       overrides.popContext()
     }
   }

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/plugins/xml/BadgerFishHandler.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/plugins/xml/BadgerFishHandler.scala
@@ -72,7 +72,9 @@ class BadgerFishHandler(params: EffectiveParams) extends DefaultHandler2 {
       if (!declaredXmlns.isEmpty) declaredXmlns = new util.LinkedHashMap() // re-use map of xmlns -- tradeoff of speed for memory(clear map values)
     }
 
-    val newPrefix = if (prefix.equals("xmlns")) DefaultXMLPlugin.DEFAULT_NS_KEY else overrides.prefix(prefix, uri)
+    // SAX reports a default-namespace declaration as the empty prefix, which maps to the default-ns key
+    val computed = if (prefix.equals("xmlns")) "" else overrides.prefix(prefix, uri)
+    val newPrefix = if (computed.isEmpty) DefaultXMLPlugin.DEFAULT_NS_KEY else computed
     if (!params.excludeXmlns) declaredXmlns.put(newPrefix, memberOf(Val.Str(dummyPos, uri)))
   }
 

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/plugins/xml/BadgerFishHandler.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/plugins/xml/BadgerFishHandler.scala
@@ -31,6 +31,7 @@ package io.github.jam01.xtrasonnet.plugins.xml
  * - 1570c045ab8e750305e1d86206f4cddeadabfedd: conformed badgerfish ordering behavior
  * - de7029978b65a012dfdb8dd32b598e99a9c7708a: renamed currentNS to declaredXmlns, only start new xmlns context when
  *    xmlns found, use new NamespaceDeclarations
+ * - 487f7939b08dfb9e75aa3ed4728a9e23e89d57dd: map the empty default-namespace prefix to the _def key
  */
 
 import io.github.jam01.xtrasonnet.plugins.DefaultXMLPlugin

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/plugins/xml/BadgerFishVisitor.scala
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/plugins/xml/BadgerFishVisitor.scala
@@ -157,7 +157,7 @@ final class BadgerFishVisitor(val params: EffectiveParams) {
               val k = kvv.getKey
               val vv = kvv.getValue
               out.append(" xmlns")
-              if (k != null && k != DEFAULT_NS_KEY) out.append(':').append(k)
+              if (k != null && k.nonEmpty && k != DEFAULT_NS_KEY) out.append(':').append(k)
               out.append('=')
               val tmp = new StringWriter()
               val raw: String = if (vv != null && vv.isTextual) vv.asText() else ""

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/plugins/xml/NamespaceDeclarations.java
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/plugins/xml/NamespaceDeclarations.java
@@ -1,12 +1,13 @@
 package io.github.jam01.xtrasonnet.plugins.xml;
 
 /*-
- * Copyright 2022 Jose Montoya.
+ * Copyright 2022-2026 Jose Montoya.
  *
  * Licensed under the Elastic License 2.0; you may not use this file except in
  * compliance with the Elastic License 2.0.
  */
 
+import io.github.jam01.xtrasonnet.plugins.DefaultXMLPlugin;
 import org.xml.sax.helpers.NamespaceSupport;
 
 import java.util.HashMap;
@@ -33,7 +34,9 @@ public class NamespaceDeclarations {
         if (requested.containsKey(uri)) { // if a prefix is requested for this uri, use that
             override = requested.get(uri);
             overridden.put(prefix, override);
-        } else if (requested.containsValue(prefix)) { // if prefix is requested for another uri, find an override
+        } else if (requested.containsValue(prefix)
+                // reserved for the default declaration, which a literal prefix must not collide with
+                || DefaultXMLPlugin.DEFAULT_NS_KEY().equals(prefix)) {
             var i = 1;
             do {
                 // https://saxonica.plan.io/projects/saxonmirrorhe/repository/he/entry/src/main/java/net/sf/saxon/event/ComplexContentOutputter.java?utf8=%E2%9C%93&rev=he_mirror_saxon_11_4#L588

--- a/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/plugins/xml/NamespaceDeclarations.java
+++ b/xtrasonnet/src/main/scala/io/github/jam01/xtrasonnet/plugins/xml/NamespaceDeclarations.java
@@ -10,18 +10,23 @@ package io.github.jam01.xtrasonnet.plugins.xml;
 import io.github.jam01.xtrasonnet.plugins.DefaultXMLPlugin;
 import org.xml.sax.helpers.NamespaceSupport;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
 
 public class NamespaceDeclarations {
     private final NamespaceSupport wrapped = new NamespaceSupport();
     private final Map<String, String> requested; // consider a bi-directional Map
-    private final Map<String, String> overridden = new HashMap<>(8); // consider a bi-directional Map
+    // one map of overrides per active context, scoped the same as wrapped's own declarations;
+    // nearest (innermost, i.e. first) context wins on lookup, mirroring wrapped's inheritance
+    private final Deque<Map<String, String>> overridden = new ArrayDeque<>();
     private final String[] parts = new String[3];  // keep reusing a single array
 
     public NamespaceDeclarations(Map<String, String> requested) {
         requested.forEach((uri, pfx) -> wrapped.declarePrefix(pfx, uri));
         this.requested = requested;
+        overridden.push(new HashMap<>(4)); // root context, mirrors wrapped's implicit base context
     }
 
     // convenience of NamespaceSupport.declarePrefix that returns the potentially overridden prefix
@@ -33,8 +38,9 @@ public class NamespaceDeclarations {
         var override = prefix;
         if (requested.containsKey(uri)) { // if a prefix is requested for this uri, use that
             override = requested.get(uri);
-            overridden.put(prefix, override);
+            overridden.peek().put(prefix, override);
         } else if (requested.containsValue(prefix)
+                || overriddenHasValue(prefix) // already used to override another prefix in an active context
                 // reserved for the default declaration, which a literal prefix must not collide with
                 || DefaultXMLPlugin.DEFAULT_NS_KEY().equals(prefix)) {
             var i = 1;
@@ -44,10 +50,10 @@ public class NamespaceDeclarations {
                 // https://suika.suikawiki.org/www/markup/xml/nsfixup
                 override = prefix + '_' + i;
                 i++;
-            } while (requested.containsValue(override) || wrapped.getURI(override) != null || overridden.containsValue(override));
+            } while (requested.containsValue(override) || wrapped.getURI(override) != null || overriddenHasValue(override));
             // keep trying if candidate is also requested, or already declared, or already used to override another
 
-            overridden.put(prefix, override);
+            overridden.peek().put(prefix, override);
         }
 
         wrapped.declarePrefix(override, uri);
@@ -59,7 +65,8 @@ public class NamespaceDeclarations {
         int index = qName.indexOf(':');
         if (index != -1) {
             var prefix = qName.substring(0, index);
-            if (overridden.containsKey(prefix)) qName = overridden.get(prefix) + qName.substring(index);
+            var override = overriddenValue(prefix);
+            if (override != null) qName = override + qName.substring(index);
         }
 
         return wrapped.processName(qName, parts, isAttribute)[2]; // parts is a multi-return value placeholder
@@ -67,9 +74,28 @@ public class NamespaceDeclarations {
 
     public void pushContext() {
         wrapped.pushContext();
+        overridden.push(new HashMap<>(4));
     }
 
     public void popContext() {
         wrapped.popContext();
+        overridden.pop();
+    }
+
+    // nearest-context-first lookup of the override recorded for a literal prefix, or null if none
+    private String overriddenValue(String prefix) {
+        for (Map<String, String> context : overridden) {
+            var override = context.get(prefix);
+            if (override != null) return override;
+        }
+        return null;
+    }
+
+    // whether some active context has already used this string as an override target
+    private boolean overriddenHasValue(String value) {
+        for (Map<String, String> context : overridden) {
+            if (context.containsValue(value)) return true;
+        }
+        return false;
     }
 }

--- a/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/ArraysTest.java
+++ b/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/ArraysTest.java
@@ -145,11 +145,11 @@ public class ArraysTest {
         Assertions.assertEquals(TestUtils.transform("[]"), TestUtils.transform("xtr.arrays.unzip([])"));
     }
 
-//    @Disabled
-//    @Test
-//    public void unzipAll() {
-//        assertEquals(transform("[[1, 2, 3], ['x', 'NA', 'z']]"), transform("xtr.arrays.unzipAll([[1, 'x'], [2], [3, 'z']], 'NA')"));
-//    }
+    @Test
+    public void unzipAll() {
+        Assertions.assertEquals(TestUtils.transform("[[1, 2, 3], ['x', 'NA', 'z']]"), TestUtils.transform("xtr.arrays.unzipAll([[1, 'x'], [2], [3, 'z']], 'NA')"));
+        Assertions.assertEquals(TestUtils.transform("[]"), TestUtils.transform("xtr.arrays.unzipAll([], 'NA')"));
+    }
 
     @Test
     public void zip() {
@@ -163,9 +163,10 @@ public class ArraysTest {
         Assertions.assertEquals(TestUtils.transform("[]"), TestUtils.transform("xtr.arrays.zip([1, 2, 3], [])"));
     }
 
-//    @Disabled
-//    @Test
-//    public void zipAll() {
-//        assertEquals(transform("[[1, 'x'], [2, 'y'], [3, 'NA']]"), transform("txtr.arrays.zipAll([[1, 2, 3], ['x', 'y']], 'NA')"));
-//    }
+    @Test
+    public void zipAll() {
+        Assertions.assertEquals(TestUtils.transform("[[1, 'x'], [2, 'y'], [3, 'NA']]"), TestUtils.transform("xtr.arrays.zipAll([[1, 2, 3], ['x', 'y']], 'NA')"));
+        Assertions.assertEquals(TestUtils.transform("[[1, null], [2, null], [3, null]]"), TestUtils.transform("xtr.arrays.zipAll([[1, 2, 3], []], null)"));
+        Assertions.assertEquals(TestUtils.transform("[]"), TestUtils.transform("xtr.arrays.zipAll([], 'NA')"));
+    }
 }

--- a/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/DatetimeTest.java
+++ b/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/DatetimeTest.java
@@ -127,4 +127,11 @@ public class DatetimeTest {
         Assertions.assertEquals(TestUtils.transform("'2019-07-10T21:34:56Z'"),
                 TestUtils.transform("xtr.datetime.of(xtr.datetime.toParts('2019-07-10T21:34:56Z'))"));
     }
+
+    @Test
+    public void ofRejectsUnknownParts() {
+        var ex = Assertions.assertThrows(RuntimeException.class,
+                () -> TestUtils.transform("xtr.datetime.of({years: 2021})"));
+        Assertions.assertTrue(ex.getMessage().contains("Unexpected datetime part: years"), ex.getMessage());
+    }
 }

--- a/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/DatetimeTest.java
+++ b/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/DatetimeTest.java
@@ -103,6 +103,30 @@ public class DatetimeTest {
     }
 
     @Test
+    public void plusMinus_timeOnlyDurations() {
+        Assertions.assertEquals(TestUtils.transform("'2019-09-18T20:53:41Z'"), TestUtils.transform("xtr.datetime.plus('2019-09-18T18:53:41Z', 'PT2H')"));
+        Assertions.assertEquals(TestUtils.transform("'2019-09-18T16:53:41Z'"), TestUtils.transform("xtr.datetime.minus('2019-09-18T18:53:41Z', 'PT2H')"));
+
+        // composes with duration.of, whose canonical output is time-only for time-only parts
+        Assertions.assertEquals(TestUtils.transform("'2019-09-18T20:53:41Z'"),
+                TestUtils.transform("xtr.datetime.plus('2019-09-18T18:53:41Z', xtr.duration.of({hours: 2}))"));
+    }
+
+    @Test
+    public void plusMinus_negativeDurationAppliesToAllParts() {
+        // -P1DT2H is minus(1 day and 2 hours); subtracting it adds both parts
+        Assertions.assertEquals(TestUtils.transform("'2019-09-21T20:53:41Z'"), TestUtils.transform("xtr.datetime.minus('2019-09-20T18:53:41Z', '-P1DT2H')"));
+        Assertions.assertEquals(TestUtils.transform("'2019-09-19T16:53:41Z'"), TestUtils.transform("xtr.datetime.plus('2019-09-20T18:53:41Z', '-P1DT2H')"));
+    }
+
+    @Test
+    public void plusMinus_invalidDuration() {
+        var ex = Assertions.assertThrows(RuntimeException.class,
+                () -> TestUtils.transform("xtr.datetime.plus('2019-09-18T18:53:41Z', '2 days')"));
+        Assertions.assertTrue(ex.getMessage().contains("Invalid ISO-8601 duration: 2 days"), ex.getMessage());
+    }
+
+    @Test
     public void toLocal() {
         Assertions.assertEquals(TestUtils.transform("'2019-07-04'"), TestUtils.transform("xtr.datetime.toLocalDate('2019-07-04T18:53:41Z')"));
         Assertions.assertEquals(TestUtils.transform("'2019-07-04T21:00:00'"), TestUtils.transform("xtr.datetime.toLocalDateTime('2019-07-04T21:00:00Z')"));

--- a/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/DurationTest.java
+++ b/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/DurationTest.java
@@ -64,6 +64,34 @@ public class DurationTest {
     }
 
     @Test
+    public void fractionalSeconds() {
+        assertEquals(transform("'PT1.5S'"), transform("xtr.duration.of({seconds: 1.5})"));
+        assertEquals(transform("'PT1M30.25S'"), transform("xtr.duration.of({seconds: 90.25})"));
+
+        assertEquals(transform("""
+                        {
+                            years: 0, months: 0, days: 0,
+                            hours: 0, minutes: 0, seconds: 1.5
+                        }"""),
+                transform("xtr.duration.toParts('PT1.5S')"));
+        assertEquals(transform("""
+                        {
+                            years: 0, months: 0, days: 0,
+                            hours: 0, minutes: 0, seconds: -1.5
+                        }"""),
+                transform("xtr.duration.toParts('-PT1.5S')"));
+
+        assertEquals(transform("'PT1.5S'"),
+                transform("xtr.duration.of(xtr.duration.toParts('PT1.5S'))"));
+    }
+
+    @Test
+    public void ofRejectsFractionsAboveSeconds() {
+        var ex = assertThrows(RuntimeException.class, () -> transform("xtr.duration.of({hours: 1.5})"));
+        assertTrue(ex.getMessage().contains("Expected a whole number for duration part hours"), ex.getMessage());
+    }
+
+    @Test
     public void ofRejectsUnknownParts() {
         var ex = assertThrows(RuntimeException.class, () -> transform("xtr.duration.of({hour: 1})"));
         assertTrue(ex.getMessage().contains("Unexpected duration part: hour"), ex.getMessage());

--- a/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/DurationTest.java
+++ b/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/DurationTest.java
@@ -6,11 +6,12 @@ package io.github.jam01.xtrasonnet.modules;
  * Licensed under the Elastic License 2.0; you may not use this file except in
  * compliance with the Elastic License 2.0.
  */
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static io.github.jam01.xtrasonnet.TestUtils.transform;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DurationTest {
     @Test
@@ -43,15 +44,75 @@ public class DurationTest {
                 transform("xtr.duration.of(xtr.duration.toParts('P2Y3M4DT5H'))"));
     }
 
-    @Disabled("duration prints P3DT0S which is valid")
     @Test
     public void toPartsAndOfRoundTrip_dateOnlyAndTimeOnlyStyle() {
         // date-only
         assertEquals(transform("'P3D'"),
                 transform("xtr.duration.of(xtr.duration.toParts('P3D'))"));
 
-        // time-only style expressed with an explicit 0D (common safe representation)
-        assertEquals(transform("'P0DT2H'"),
+        // an explicit 0D collapses to the canonical time-only form
+        assertEquals(transform("'PT2H'"),
                 transform("xtr.duration.of(xtr.duration.toParts('P0DT2H'))"));
+    }
+
+    @Test
+    public void ofIsCanonical() {
+        assertEquals(transform("'PT1H'"), transform("xtr.duration.of({hours: 1})"));
+        assertEquals(transform("'P1Y'"), transform("xtr.duration.of({years: 1})"));
+        assertEquals(transform("'PT0S'"), transform("xtr.duration.of({})"));
+        assertEquals(transform("'PT1M30S'"), transform("xtr.duration.of({seconds: 90})"));
+    }
+
+    @Test
+    public void ofRejectsUnknownParts() {
+        var ex = assertThrows(RuntimeException.class, () -> transform("xtr.duration.of({hour: 1})"));
+        assertTrue(ex.getMessage().contains("Unexpected duration part: hour"), ex.getMessage());
+    }
+
+    @Test
+    public void toPartsTimeOnly() {
+        assertEquals(transform("""
+                        {
+                            years: 0, months: 0, days: 0,
+                            hours: 4, minutes: 5, seconds: 6
+                        }"""),
+                transform("xtr.duration.toParts('PT4H5M6S')"));
+    }
+
+    @Test
+    public void toPartsDateOnlyIncludesTimeParts() {
+        assertEquals(transform("""
+                        {
+                            years: 0, months: 0, days: 40,
+                            hours: 0, minutes: 0, seconds: 0
+                        }"""),
+                transform("xtr.duration.toParts('P40D')"));
+    }
+
+    @Test
+    public void toPartsNegative() {
+        assertEquals(transform("""
+                        {
+                            years: 0, months: 0, days: -1,
+                            hours: -2, minutes: -30, seconds: 0
+                        }"""),
+                transform("xtr.duration.toParts('-P1DT2H30M')"));
+
+        assertEquals(transform("""
+                        {
+                            years: 0, months: 0, days: 0,
+                            hours: -4, minutes: 0, seconds: 0
+                        }"""),
+                transform("xtr.duration.toParts('PT-4H')"));
+    }
+
+    @Test
+    public void toPartsInvalid() {
+        var ex = assertThrows(RuntimeException.class, () -> transform("xtr.duration.toParts('4 hours')"));
+        assertTrue(ex.getMessage().contains("Invalid ISO-8601 duration: 4 hours"), ex.getMessage());
+
+        // 'T' with no time components is invalid, as is a bare 'P'
+        assertThrows(RuntimeException.class, () -> transform("xtr.duration.toParts('P1DT')"));
+        assertThrows(RuntimeException.class, () -> transform("xtr.duration.toParts('P')"));
     }
 }

--- a/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/DurationTest.java
+++ b/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/DurationTest.java
@@ -107,6 +107,13 @@ public class DurationTest {
     }
 
     @Test
+    public void toPartsOverflowIsAnEvaluationError() {
+        // negating Integer.MIN_VALUE years overflows; it must surface as the uniform parse error
+        var ex = assertThrows(RuntimeException.class, () -> transform("xtr.duration.toParts('-P-2147483648Y')"));
+        assertTrue(ex.getMessage().contains("Invalid ISO-8601 duration"), ex.getMessage());
+    }
+
+    @Test
     public void toPartsInvalid() {
         var ex = assertThrows(RuntimeException.class, () -> transform("xtr.duration.toParts('4 hours')"));
         assertTrue(ex.getMessage().contains("Invalid ISO-8601 duration: 4 hours"), ex.getMessage());

--- a/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/ObjectsTest.java
+++ b/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/ObjectsTest.java
@@ -332,6 +332,35 @@ public class ObjectsTest {
     }
 
     @Test
+    public void innerEqJoinPreservesLeftOrder() {
+        // rows follow the left side's order, not the right's
+        assertEquals(transform("""
+                        [
+                            { id: 2, b: 'z', a: 'x' },
+                            { id: 1, b: 'y', a: 'w' }
+                        ]"""),
+                transform("""
+                        xtr.objects.innerEqJoin(
+                            [{ id: 2, a: 'x' }, { id: 1, a: 'w' }],
+                            [{ id: 1, b: 'y' }, { id: 2, b: 'z' }],
+                            function(o) o.id, function(o) o.id)"""));
+
+        // duplicate keys expand left-major: each left row with all its right matches, in right order
+        assertEquals(transform("""
+                        [
+                            { id: 1, b: 'y', a: 'x' },
+                            { id: 1, b: 'y2', a: 'x' },
+                            { id: 1, b: 'y', a: 'x2' },
+                            { id: 1, b: 'y2', a: 'x2' }
+                        ]"""),
+                transform("""
+                        xtr.objects.innerEqJoin(
+                            [{ id: 1, a: 'x' }, { id: 1, a: 'x2' }],
+                            [{ id: 1, b: 'y' }, { id: 1, b: 'y2' }],
+                            function(o) o.id, function(o) o.id)"""));
+    }
+
+    @Test
     public void fullEqJoinPreservesInputOrder() {
         // matched and unmatched left rows in left order, then unmatched right rows in right order
         assertEquals(transform("""

--- a/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/ObjectsTest.java
+++ b/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/ObjectsTest.java
@@ -330,4 +330,35 @@ public class ObjectsTest {
                     function(cust) cust.id, function(order) order.customerId,
                     function(cust, order) { l: cust, r: order })"""), false);
     }
+
+    @Test
+    public void fullEqJoinPreservesInputOrder() {
+        // matched and unmatched left rows in left order, then unmatched right rows in right order
+        assertEquals(transform("""
+                        [
+                            { id: 2, a: 'x' },
+                            { id: 1, b: 'y', a: 'w' },
+                            { id: 10, a: 'q' },
+                            { id: 7, b: 'z' }
+                        ]"""),
+                transform("""
+                        xtr.objects.fullEqJoin(
+                            [{ id: 2, a: 'x' }, { id: 1, a: 'w' }, { id: 10, a: 'q' }],
+                            [{ id: 1, b: 'y' }, { id: 7, b: 'z' }],
+                            function(o) o.id, function(o) o.id)"""));
+
+        assertEquals(transform("""
+                        [
+                            { l: 2, r: null },
+                            { l: 1, r: 1 },
+                            { l: 10, r: null },
+                            { l: null, r: 7 }
+                        ]"""),
+                transform("""
+                        xtr.objects.fullEqJoin(
+                            [{ id: 2 }, { id: 1 }, { id: 10 }],
+                            [{ id: 1 }, { id: 7 }],
+                            function(o) o.id, function(o) o.id,
+                            function(l, r) { l: l?.id, r: r?.id })"""));
+    }
 }

--- a/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/ObjectsTest.java
+++ b/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/ObjectsTest.java
@@ -1,7 +1,7 @@
 package io.github.jam01.xtrasonnet.modules;
 
 /*-
- * Copyright 2022 Jose Montoya.
+ * Copyright 2022-2026 Jose Montoya.
  *
  * Licensed under the Elastic License 2.0; you may not use this file except in
  * compliance with the Elastic License 2.0.

--- a/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/StringsTest.java
+++ b/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/StringsTest.java
@@ -183,4 +183,38 @@ public class StringsTest {
     public void wrapIfMissing() {
         assertEquals(transform("'_Hello, world!_'"), transform("xtr.strings.wrapIfMissing('_Hello, world!', '_')"));
     }
+
+    @Test
+    public void matchesRegex() {
+        assertEquals(transform("true"), transform("xtr.strings.matches('user@example.com', '\\\\w+@\\\\w+\\\\.\\\\w+')"));
+        // the entire string must match
+        assertEquals(transform("false"), transform("xtr.strings.matches('say user@example.com twice', '\\\\w+@\\\\w+\\\\.\\\\w+')"));
+        assertEquals(transform("false"), transform("xtr.strings.matches('user at example dot com', '\\\\w+@\\\\w+\\\\.\\\\w+')"));
+    }
+
+    @Test
+    public void matchRegex() {
+        assertEquals(transform("['user@example.com', 'user', 'example.com']"),
+                transform("xtr.strings.match('user@example.com', '(\\\\w+)@([\\\\w.]+)')"));
+        // no match yields null, which composes with the ?? operator
+        assertEquals(transform("null"), transform("xtr.strings.match('no email here', '(\\\\w+)@([\\\\w.]+)')"));
+        assertEquals(transform("'none'"), transform("xtr.strings.match('no email here', '(\\\\w+)@([\\\\w.]+)') ?? 'none'"));
+        // groups that did not participate in the match are null
+        assertEquals(transform("['ab', 'b', null]"), transform("xtr.strings.match('ab', 'a(b)|a(c)')"));
+    }
+
+    @Test
+    public void scanRegex() {
+        assertEquals(transform("[['a1@b1.com', 'a1', 'b1.com'], ['a2@b2.com', 'a2', 'b2.com']]"),
+                transform("xtr.strings.scan('write to a1@b1.com or a2@b2.com', '(\\\\w+)@([\\\\w.]+)')"));
+        assertEquals(transform("[]"), transform("xtr.strings.scan('nothing to find', '(\\\\d+)')"));
+        // no capture groups: each match is just the matched string
+        assertEquals(transform("[['1'], ['2']]"), transform("xtr.strings.scan('1 and 2', '\\\\d')"));
+    }
+
+    @Test
+    public void invalidRegex() {
+        var ex = assertThrows(XtrasonnetException.class, () -> transform("xtr.strings.matches('abc', '[')"));
+        assertTrue(ex.getMessage().contains("Invalid regular expression"), ex.getMessage());
+    }
 }

--- a/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/StringsTest.java
+++ b/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/modules/StringsTest.java
@@ -85,6 +85,13 @@ public class StringsTest {
     }
 
     @Test
+    public void pad_stringifiesNumbersLikeToString() {
+        assertEquals(transform("'0003.7'"), transform("xtr.strings.leftPad(3.7, 6, '0')"));
+        assertEquals(transform("'3.7000'"), transform("xtr.strings.rightPad(3.7, 6, '0')"));
+        assertEquals(transform("'  42'"), transform("xtr.strings.leftPad(42, 4, ' ')"));
+    }
+
+    @Test
     public void capitalize_withoutAnyAlphanumericCharacter() {
         assertEquals(transform("'---'"), transform("xtr.strings.capitalize('---')"));
         assertEquals(transform("''"), transform("xtr.strings.capitalize('')"));

--- a/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/plugins/XMLPluginTest.java
+++ b/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/plugins/XMLPluginTest.java
@@ -124,6 +124,18 @@ public class XMLPluginTest {
     }
 
     @Test
+    public void literal_def_prefix_doesNotCollideWithDefaultNamespace() throws JSONException {
+        // a document prefix literally named _def is overridden so the default declaration keeps its key
+        var json = new Transformer("payload")
+                .transform(Document.of(
+                        "<r xmlns='http://ex.org/u2' xmlns:_def='http://ex.org/u1'><_def:a>1</_def:a></r>",
+                        MediaTypes.APPLICATION_XML));
+        JSONAssert.assertEquals("{\"r\":{\"_xmlns\":{\"_def\":\"http://ex.org/u2\",\"_def_1\":\"http://ex.org/u1\"},"
+                        + "\"_def_1:a\":{\"_text\":\"1\"}}}",
+                json.getContent(), true);
+    }
+
+    @Test
     public void read_rejectsDoctypeAndExternalEntities() {
         // XMLLoader disables DTDs and both external entity classes. Nothing asserted that, so a
         // regression would have shipped silently; this is one line away at all times.

--- a/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/plugins/XMLPluginTest.java
+++ b/xtrasonnet/src/test/java/io/github/jam01/xtrasonnet/plugins/XMLPluginTest.java
@@ -109,6 +109,21 @@ public class XMLPluginTest {
     }
 
     @Test
+    public void default_xmlns_roundTrip() throws JSONException {
+        // a default namespace declaration reads under the documented _def key...
+        var json = new Transformer("payload")
+                .transform(Document.of("<root xmlns='http://example.org/ns'><a>1</a></root>", MediaTypes.APPLICATION_XML));
+        JSONAssert.assertEquals("{\"root\":{\"_xmlns\":{\"_def\":\"http://example.org/ns\"},\"a\":{\"_text\":\"1\"}}}",
+                json.getContent(), true);
+
+        // ...and writes back as a well-formed default declaration, not 'xmlns:='
+        var xml = new Transformer(json.getContent())
+                .transform(Documents.Null(), Collections.emptyMap(), MediaTypes.APPLICATION_XML);
+        assertThat(xml.getContent(), CompareMatcher.isSimilarTo("<root xmlns='http://example.org/ns'><a>1</a></root>")
+                .ignoreWhitespace().throwComparisonFailure());
+    }
+
+    @Test
     public void read_rejectsDoctypeAndExternalEntities() {
         // XMLLoader disables DTDs and both external entity classes. Nothing asserted that, so a
         // regression would have shipped silently; this is one line away at all times.


### PR DESCRIPTION
- duration: time-only/negative/fractional-second parsing, canonical `of` output, strict part names; parsing shared with `datetime.plus`/`minus`
- joins: one shared core, deterministic left-major ordering
- new: `strings.match`/`matches`/`scan` (with pattern cache), `arrays.zipAll`/`unzipAll`
- pads stringify numbers like `toString`; `datetime.of` rejects unknown parts
- XML: default namespace reads as `_def` and writes well-formed; literal `_def` prefix overridden
- docs aligned with implementation (~130 signatures, examples execute-verified)

Every behavior change is pinned by a test verified to fail with the fix reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018k8EcwdtBTg9gVjTTQ7RQn